### PR TITLE
feat: ✨ add accessibility testing to Storybook

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,8 +1,18 @@
 import type { TestRunnerConfig } from "@storybook/test-runner";
+import { injectAxe, checkA11y } from "axe-playwright";
 
 const config: TestRunnerConfig = {
+  async preVisit(page) {
+    await injectAxe(page);
+  },
   async postVisit(page) {
     await page.waitForLoadState("networkidle");
+
+    await checkA11y(page, "#storybook-root", {
+      includedImpacts: ["critical"],
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
   },
   tags: {
     skip: ["test:skip"],

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@vanilla-extract/webpack-plugin": "^2.3.16",
     "@vitejs/plugin-react": "^5.0.1",
     "@vitest/ui": "^3.2.4",
+    "axe-playwright": "^2.1.0",
     "concurrently": "^9.2.1",
     "devmoji": "^2.3.0",
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
+      axe-playwright:
+        specifier: ^2.1.0
+        version: 2.1.0(playwright@1.55.0)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -2190,6 +2193,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/junit-report-builder@3.0.2':
+    resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
+
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
 
@@ -2832,6 +2838,17 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
+
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
+
+  axe-playwright@2.1.0:
+    resolution: {integrity: sha512-tY48SX56XaAp16oHPyD4DXpybz8Jxdz9P7exTjF/4AV70EGUavk+1fUPWirM0OYBR+YyDx6hUeDvuHVA6fB9YA==}
+    peerDependencies:
+      playwright: '>1.0.0'
 
   axios@1.11.0:
     resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
@@ -5347,6 +5364,10 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  junit-report-builder@5.1.1:
+    resolution: {integrity: sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==}
+    engines: {node: '>=16'}
+
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
@@ -5919,6 +5940,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -7918,6 +7943,10 @@ packages:
 
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -10309,6 +10338,8 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/junit-report-builder@3.0.2': {}
+
   '@types/katex@0.16.7': {}
 
   '@types/mdast@3.0.15':
@@ -11089,6 +11120,20 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.3: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.10.3):
+    dependencies:
+      axe-core: 4.10.3
+      mustache: 4.2.0
+
+  axe-playwright@2.1.0(playwright@1.55.0):
+    dependencies:
+      '@types/junit-report-builder': 3.0.2
+      axe-core: 4.10.3
+      axe-html-reporter: 2.2.11(axe-core@4.10.3)
+      junit-report-builder: 5.1.1
+      picocolors: 1.1.1
+      playwright: 1.55.0
 
   axios@1.11.0:
     dependencies:
@@ -14351,6 +14396,12 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  junit-report-builder@5.1.1:
+    dependencies:
+      lodash: 4.17.21
+      make-dir: 3.1.0
+      xmlbuilder: 15.1.1
+
   katex@0.16.22:
     dependencies:
       commander: 8.3.0
@@ -15176,6 +15227,8 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mute-stream@1.0.0: {}
 
@@ -17603,6 +17656,8 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xml@1.0.1: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 

--- a/src/shared/design-system/tokens/font/fonts.stories.tsx
+++ b/src/shared/design-system/tokens/font/fonts.stories.tsx
@@ -18,9 +18,9 @@ export const FontFamilies = () => {
   return (
     <div>
       <div>
-        <label htmlFor="input">プレビュー用テキスト</label>
+        <label htmlFor="font-families-input">プレビュー用テキスト</label>
         <input
-          id="input"
+          id="font-families-input"
           // eslint-disable-next-line react/jsx-handler-names
           onChange={(e) => setInputValue(e.target.value)}
           style={{
@@ -67,9 +67,9 @@ export const FontSizes = () => {
   return (
     <div>
       <div>
-        <label htmlFor="input">プレビュー用テキスト</label>
+        <label htmlFor="font-sizes-input">プレビュー用テキスト</label>
         <input
-          id="input"
+          id="font-sizes-input"
           // eslint-disable-next-line react/jsx-handler-names
           onChange={(e) => setInputValue(e.target.value)}
           style={{

--- a/src/shared/design-system/tokens/font/fonts.stories.tsx
+++ b/src/shared/design-system/tokens/font/fonts.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta } from "@storybook/nextjs";
 import { useState } from "react";
 
+import { colors } from "@/shared/design-system/tokens/color/colors";
+
 import { fontFamilies } from "./font-families";
 import { fontSizes } from "./font-sizes";
 
@@ -16,13 +18,17 @@ export const FontFamilies = () => {
   return (
     <div>
       <div>
+        <label htmlFor="input">プレビュー用テキスト</label>
         <input
+          id="input"
           // eslint-disable-next-line react/jsx-handler-names
           onChange={(e) => setInputValue(e.target.value)}
           style={{
             padding: "4px",
-            border: "gray 1px solid",
-            color: "gray",
+            border: `1px solid ${colors.palette.gray[400]}`,
+            backgroundColor: colors.background.secondary,
+            color: colors.text.primary,
+            borderRadius: "4px",
           }}
           type="text"
           value={inputValue}
@@ -61,13 +67,17 @@ export const FontSizes = () => {
   return (
     <div>
       <div>
+        <label htmlFor="input">プレビュー用テキスト</label>
         <input
+          id="input"
           // eslint-disable-next-line react/jsx-handler-names
           onChange={(e) => setInputValue(e.target.value)}
           style={{
             padding: "4px",
-            border: "gray 1px solid",
-            color: "gray",
+            border: `1px solid ${colors.palette.gray[400]}`,
+            backgroundColor: colors.background.secondary,
+            color: colors.text.primary,
+            borderRadius: "4px",
           }}
           type="text"
           value={inputValue}


### PR DESCRIPTION
## Summary

- Add axe-playwright for automated accessibility testing in Storybook test-runner
- Configure test-runner to check critical accessibility violations only
- Improve font stories with proper labels and color contrast for better UX
- Enable `pnpm a11y` command for continuous accessibility validation

## Test plan

- [x] Automated tests pass (vitest)
- [x] Accessibility tests run successfully with critical-level violations only
- [x] Storybook builds and serves correctly
- [x] Font stories display proper labels and contrast
- [x] ESLint and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)