### PR TITLE
feat: game と webapp を sitemap に追加

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,16 @@
 import type { MetadataRoute } from "next";
 
+import { readGameContents } from "@/contents/games/reader";
+import { readWebappContents } from "@/contents/webapps/reader";
 import { readWritingContents } from "@/contents/writings/reader";
 
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
-  // TODO: まとめる
   const basePath = "https://syakoo-lab.com";
 
   const writingContents = await readWritingContents();
+  // NOTE: Art は二次創作イラストを含むため、意図的にサイトマップから除外している
+  const gameContents = await readGameContents();
+  const webappContents = readWebappContents();
 
   return [
     {
@@ -19,6 +23,16 @@ const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
         url: `${basePath}/writings/${frontMatter.id}`,
         lastModified: frontMatter.updated ?? frontMatter.published,
       })),
+    ...gameContents
+      .filter(({ frontMatter }) => !frontMatter.noindex)
+      .map(({ frontMatter }) => ({
+        url: `${basePath}/creations/${frontMatter.id}`,
+        lastModified: frontMatter.updated ?? frontMatter.published,
+      })),
+    ...webappContents.map((webapp) => ({
+      url: `${basePath}/creations/${webapp.id}`,
+      lastModified: webapp.releasedAt,
+    })),
   ];
 };
 


### PR DESCRIPTION
## 概要

サイトマップに Game と Webapp のオリジナル作品を追加しました。

## 変更内容

- `readGameContents` と `readWebappContents` を使って、Game と Webapp を sitemap に追加
- Game は `noindex` フラグでフィルタリング（将来非公開にしたいゲームがあれば対応可能）
- Webapp は全てオリジナル作品のため、そのまま全て追加

## 除外したもの

- **Art（イラスト）**: 二次創作イラストを含むため、意図的にサイトマップから除外しています
  - コメントで理由を記載済み