### PR TITLE
chore: update safe-chain CI configuration

### DIFF
--- a/.github/actions/setup-safe-chain/action.yml
+++ b/.github/actions/setup-safe-chain/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Install safe-chain
       shell: bash
-      run: npm install -g @aikidosec/safe-chain
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/actions/setup-safe-chain/action.yml
+++ b/.github/actions/setup-safe-chain/action.yml
@@ -6,4 +6,5 @@ runs:
   steps:
     - name: Install safe-chain
       shell: bash
-      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      # renovate: datasource=github-releases depName=AikidoSec/safe-chain
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.1/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
       - name: Setup Safe Chain
         uses: ./.github/actions/setup-safe-chain
 
+      - name: Verify safe-chain protection
+        run: pnpm safe-chain-verify
+
       - name: Install dependencies with safe-chain
-        run: aikido-pnpm install
+        run: pnpm install --frozen-lockfile
+        env:
+          SAFE_CHAIN_LOGGING: verbose
 
   lint:
     needs: security-scan


### PR DESCRIPTION
## 変更内容

- safe-chain のインストール方法を `npm install -g` から `curl` 方式に更新
- `pnpm safe-chain-verify` ステップを追加して保護が有効か確認
- `SAFE_CHAIN_LOGGING=verbose` を有効化して詳細ログを出力
- `aikido-pnpm install` → `pnpm install --frozen-lockfile` に変更

## 理由

- Aikido 推奨の CI/CD 向けインストール方法に準拠
- セキュリティスキャンが正常に動作していることをログで確認できるように