### PR TITLE
fix: 🐛 quote placeholder value to fix YAML syntax error

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       label: 背景・目的
       description: この要望を出すに至った背景や目的を記載してください
-      placeholder: 例: ユーザーが〇〇をしたい時に、現在は△△という手順が必要で不便に感じているため...
+      placeholder: "例: ユーザーが〇〇をしたい時に、現在は△△という手順が必要で不便に感じているため..."
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- Issue テンプレートの YAML 構文エラーを修正
- placeholder の値にコロンが含まれていたため、ダブルクォートで囲んで対応

## Test plan
- [ ] GitHub の Issue 作成画面でテンプレートが正常に表示されることを確認