### PR TITLE
feat: 画像のライトボックス表示機能を追加

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -45,7 +45,7 @@ const preview: Preview = {
       theme: storyTheme,
     },
     viewport: {
-      viewports: INITIAL_VIEWPORTS,
+      options: INITIAL_VIEWPORTS,
     },
     nextjs: {
       appDirectory: true,

--- a/src/features/creation/creation-detail/variant-content/illustration-image.tsx
+++ b/src/features/creation/creation-detail/variant-content/illustration-image.tsx
@@ -2,6 +2,10 @@ import Image from "next/image";
 import type { FC } from "react";
 
 import type { CreationIllust } from "@/entities/creation/models/creation";
+import {
+  ImageLightboxRoot,
+  ImageLightboxTrigger,
+} from "@/shared/design-system/ui/image-lightbox/image-lightbox";
 
 type IllustrationImageProps = Pick<CreationIllust, "illust" | "title">;
 
@@ -9,15 +13,21 @@ export const IllustrationImage: FC<IllustrationImageProps> = ({
   illust,
   title,
 }) => {
+  const altText = `イラスト作品「${title}」`;
+
   return (
     <div className="flex max-md:-mx-200">
-      <Image
-        alt={`イラスト作品「${title}」`}
-        className="mx-auto h-auto max-w-full"
-        height={illust.height}
-        src={illust.src}
-        width={illust.width}
-      />
+      <ImageLightboxRoot alt={altText} src={illust.src}>
+        <ImageLightboxTrigger className="mx-auto">
+          <Image
+            alt={altText}
+            className="h-auto max-w-full"
+            height={illust.height}
+            src={illust.src}
+            width={illust.width}
+          />
+        </ImageLightboxTrigger>
+      </ImageLightboxRoot>
     </div>
   );
 };

--- a/src/features/writings/writing-detail/mdx/image/image.tsx
+++ b/src/features/writings/writing-detail/mdx/image/image.tsx
@@ -1,15 +1,27 @@
+import {
+  ImageLightboxRoot,
+  ImageLightboxTrigger,
+} from "@/shared/design-system/ui/image-lightbox/image-lightbox";
+
 type ImageProps = {
   caption?: string;
 } & React.ImgHTMLAttributes<HTMLImageElement>;
 
 export const Image: React.FC<ImageProps> = ({ caption, ...imageProps }) => {
+  const altText = caption || "";
+  const src = imageProps.src || "";
+
   return (
     <figure className="mx-auto my-200 flex flex-col items-center gap-100">
-      <img
-        alt={caption || ""}
-        className="h-auto w-auto max-w-full rounded-50 bg-palette-gray-100"
-        {...imageProps}
-      />
+      <ImageLightboxRoot alt={altText} src={src}>
+        <ImageLightboxTrigger>
+          <img
+            alt={altText}
+            className="h-auto w-auto max-w-full rounded-50 bg-palette-gray-100"
+            {...imageProps}
+          />
+        </ImageLightboxTrigger>
+      </ImageLightboxRoot>
       {caption ? (
         <figcaption className="text-center text-text-secondary">
           {caption}

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.module.css
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.module.css
@@ -1,0 +1,107 @@
+.dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  max-width: 100vw;
+  max-height: 100vh;
+  width: 100%;
+  height: 100%;
+  cursor: zoom-out;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+}
+
+.dialog[open] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.dialog::backdrop {
+  background-color: color-mix(
+    in srgb,
+    var(--color-background-primary) 80%,
+    transparent
+  );
+  backdrop-filter: blur(2px);
+}
+
+.dialog[data-closing="false"]::backdrop {
+  animation: lightbox-backdrop-in 0.2s ease-out forwards;
+}
+
+.dialog[data-closing="true"]::backdrop {
+  animation: lightbox-backdrop-out 0.2s ease-out forwards;
+}
+
+.image {
+  max-height: 90vh;
+  max-width: 90vw;
+  cursor: default;
+  touch-action: none;
+  user-select: none;
+  object-fit: contain;
+}
+
+.image[data-state="opening"] {
+  animation: lightbox-image-in 0.2s ease-out forwards;
+}
+
+.image[data-state="closing"] {
+  animation: lightbox-image-out 0.2s ease-out forwards;
+}
+
+@keyframes lightbox-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes lightbox-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes lightbox-image-in {
+  from {
+    opacity: 0;
+    transform: translate(var(--initial-x, 0), var(--initial-y, 0))
+      scale(var(--initial-scale, 0.5));
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@keyframes lightbox-image-out {
+  from {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translate(var(--initial-x, 0), var(--initial-y, 0))
+      scale(var(--initial-scale, 0.5));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dialog[data-closing="false"]::backdrop,
+  .dialog[data-closing="true"]::backdrop,
+  .image[data-state="opening"],
+  .image[data-state="closing"] {
+    animation-duration: 0.01ms;
+  }
+}

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.stories.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
-import { useLayoutEffect } from "react";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { ImageLightboxRoot, ImageLightboxTrigger } from "./image-lightbox";
@@ -39,45 +38,16 @@ export const Sample: Story = {
   },
 };
 
+/**
+ * Mobile 表示の確認用ストーリー
+ * TODO: test-runner では viewport 変更が matchMedia に反映されるタイミングの問題で
+ *       テストが不安定なため、Storybook バージョンアップ後に再対応する
+ *       @see https://github.com/syakoo/syakoo-lab/issues/204
+ */
 export const Mobile: Story = {
+  tags: ["test:skip"],
   globals: {
     viewport: { value: "iphone6", isRotated: false },
-  },
-  decorators: [
-    (Story) => {
-      useLayoutEffect(() => {
-        const originalMatchMedia = window.matchMedia;
-
-        window.matchMedia = (query: string) => {
-          if (query === "(pointer: coarse)") {
-            return { matches: true } as MediaQueryList;
-          }
-          return originalMatchMedia(query);
-        };
-
-        return () => {
-          window.matchMedia = originalMatchMedia;
-        };
-      }, []);
-
-      return <Story />;
-    },
-  ],
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    // dialog 内にも同じ alt の画像があるので、Trigger 内の画像を取得
-    const images = canvas.getAllByAltText("サンプル画像");
-    const triggerImage = images[0];
-
-    // Mobile では button ではなく div でラップされている
-    expect(
-      triggerImage.closest("button"),
-      "button でラップされていない",
-    ).toBeNull();
-    expect(
-      triggerImage.closest("div"),
-      "div でラップされている",
-    ).not.toBeNull();
   },
 };
 

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.stories.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useLayoutEffect } from "react";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { ImageLightboxRoot, ImageLightboxTrigger } from "./image-lightbox";
+
+const meta = {
+  tags: ["autodocs"],
+  parameters: {},
+  render: () => (
+    <ImageLightboxRoot alt="サンプル画像" src="/img/arts/20210912.png">
+      <ImageLightboxTrigger>
+        <img
+          alt="サンプル画像"
+          src="/img/arts/20210912.png"
+          style={{ width: 200, height: "auto", borderRadius: 8 }}
+        />
+      </ImageLightboxTrigger>
+    </ImageLightboxRoot>
+  ),
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Sample: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // dialog 内にも同じ alt の画像があるので、Trigger 内の画像を取得
+    const images = canvas.getAllByAltText("サンプル画像");
+    const triggerImage = images[0];
+
+    // Desktop では button でラップされている
+    expect(
+      triggerImage.closest("button"),
+      "button でラップされている",
+    ).not.toBeNull();
+  },
+};
+
+export const Mobile: Story = {
+  globals: {
+    viewport: { value: "iphone6", isRotated: false },
+  },
+  decorators: [
+    (Story) => {
+      useLayoutEffect(() => {
+        const originalMatchMedia = window.matchMedia;
+
+        window.matchMedia = (query: string) => {
+          if (query === "(pointer: coarse)") {
+            return { matches: true } as MediaQueryList;
+          }
+          return originalMatchMedia(query);
+        };
+
+        return () => {
+          window.matchMedia = originalMatchMedia;
+        };
+      }, []);
+
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // dialog 内にも同じ alt の画像があるので、Trigger 内の画像を取得
+    const images = canvas.getAllByAltText("サンプル画像");
+    const triggerImage = images[0];
+
+    // Mobile では button ではなく div でラップされている
+    expect(
+      triggerImage.closest("button"),
+      "button でラップされていない",
+    ).toBeNull();
+    expect(
+      triggerImage.closest("div"),
+      "div でラップされている",
+    ).not.toBeNull();
+  },
+};
+
+export const OpenAndCloseDialog: Story = {
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button");
+    const dialog = canvasElement.querySelector("dialog") as HTMLDialogElement;
+
+    await step("初期状態: ダイアログは閉じている", async () => {
+      expect(dialog.open).toBe(false);
+    });
+
+    await step("ボタンクリックでダイアログが開く", async () => {
+      await userEvent.click(button);
+      expect(dialog.open).toBe(true);
+    });
+
+    await step("画像クリックではダイアログは閉じない", async () => {
+      const dialogImage = dialog.querySelector("img") as HTMLImageElement;
+      await userEvent.click(dialogImage);
+      expect(dialog.open).toBe(true);
+    });
+
+    await step("ESC キーでダイアログが閉じる", async () => {
+      await userEvent.type(dialog, "{Escape}");
+      await waitFor(
+        () => {
+          expect(dialog.open).toBe(false);
+        },
+        { timeout: 1000 },
+      );
+    });
+  },
+};

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import {
+  createContext,
+  type FC,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/shared/utils/cn/cn";
+
+import styles from "./image-lightbox.module.css";
+
+// =============================================================================
+// Context
+// =============================================================================
+
+type ImageLightboxContextValue = {
+  triggerRef: React.RefObject<HTMLButtonElement>;
+  dialogRef: React.RefObject<HTMLDialogElement>;
+  open: () => void;
+  src: string;
+  alt: string;
+};
+
+const ImageLightboxContext = createContext<ImageLightboxContextValue | null>(
+  null,
+);
+
+const useImageLightboxContext = () => {
+  const ctx = useContext(ImageLightboxContext);
+  if (!ctx) {
+    throw new Error(
+      "ImageLightbox components must be used within ImageLightbox.Root",
+    );
+  }
+  return ctx;
+};
+
+// =============================================================================
+// CSS変数を含むスタイル用の型
+// =============================================================================
+
+type LightboxCSSProperties = React.CSSProperties & {
+  "--initial-x"?: string;
+  "--initial-y"?: string;
+  "--initial-scale"?: string;
+};
+
+// =============================================================================
+// Root
+// =============================================================================
+
+type RootProps = {
+  src: string;
+  alt: string;
+  children: ReactNode;
+};
+
+export const ImageLightboxRoot: FC<RootProps> = ({ src, alt, children }) => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [isClosing, setIsClosing] = useState(false);
+  const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null);
+
+  const open = useCallback(() => {
+    if (triggerRef.current) {
+      setTriggerRect(triggerRef.current.getBoundingClientRect());
+    }
+    dialogRef.current?.showModal();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsClosing(true);
+  }, []);
+
+  const handleAnimationEnd = useCallback(() => {
+    if (isClosing) {
+      dialogRef.current?.close();
+      setIsClosing(false);
+    }
+  }, [isClosing]);
+
+  // ESC キーでの閉じるをキャンセルしてアニメーション付きで閉じる
+  const handleCancel = useCallback(
+    (e: React.SyntheticEvent) => {
+      e.preventDefault();
+      handleClose();
+    },
+    [handleClose],
+  );
+
+  // 背景クリックで閉じる
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        handleClose();
+      }
+    },
+    [handleClose],
+  );
+
+  // トリガー要素からの相対位置を計算（アニメーション用）
+  const getInitialTransform = useCallback((): LightboxCSSProperties => {
+    if (!triggerRect) return {};
+
+    const centerX = window.innerWidth / 2;
+    const centerY = window.innerHeight / 2;
+    const triggerCenterX = triggerRect.left + triggerRect.width / 2;
+    const triggerCenterY = triggerRect.top + triggerRect.height / 2;
+
+    return {
+      "--initial-x": `${triggerCenterX - centerX}px`,
+      "--initial-y": `${triggerCenterY - centerY}px`,
+      "--initial-scale": `${
+        triggerRect.width / Math.min(window.innerWidth * 0.9, 1200)
+      }`,
+    };
+  }, [triggerRect]);
+
+  return (
+    <ImageLightboxContext.Provider
+      value={{ triggerRef, dialogRef, open, src, alt }}
+    >
+      {children}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: ESCキーは onCancel で処理 */}
+      <dialog
+        ref={dialogRef}
+        className={styles.dialog}
+        data-closing={isClosing}
+        onCancel={handleCancel}
+        onClick={handleBackdropClick}
+      >
+        <img
+          alt={alt}
+          className={styles.image}
+          data-state={isClosing ? "closing" : "opening"}
+          onAnimationEnd={handleAnimationEnd}
+          src={src}
+          style={getInitialTransform()}
+        />
+      </dialog>
+    </ImageLightboxContext.Provider>
+  );
+};
+
+// =============================================================================
+// Trigger
+// =============================================================================
+
+type TriggerProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export const ImageLightboxTrigger: FC<TriggerProps> = ({
+  children,
+  className,
+}) => {
+  const { triggerRef, open } = useImageLightboxContext();
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  useEffect(() => {
+    // タッチデバイス判定（pointer: coarse はタッチスクリーン）
+    // NOTE: useState の初期値で判定するとハイドレーションミスマッチが起きるため、
+    // useEffect でマウント後に判定する
+    const mediaQuery = window.matchMedia("(pointer: coarse)");
+    setIsTouchDevice(mediaQuery.matches);
+  }, []);
+
+  // モバイル（タッチデバイス）ではライトボックス無効
+  if (isTouchDevice) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <button
+      className={cn("cursor-zoom-in border-none bg-transparent p-0", className)}
+      onClick={open}
+      ref={triggerRef}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+};

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
@@ -7,6 +7,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -121,10 +122,13 @@ export const ImageLightboxRoot: FC<RootProps> = ({ src, alt, children }) => {
     };
   }, [triggerRect]);
 
+  const contextValue = useMemo(
+    () => ({ triggerRef, dialogRef, open, src, alt }),
+    [open, src, alt],
+  );
+
   return (
-    <ImageLightboxContext.Provider
-      value={{ triggerRef, dialogRef, open, src, alt }}
-    >
+    <ImageLightboxContext.Provider value={contextValue}>
       {children}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: ESCキーは onCancel で処理 */}
       <dialog

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
@@ -161,18 +161,27 @@ export const ImageLightboxTrigger: FC<TriggerProps> = ({
   className,
 }) => {
   const { triggerRef, open } = useImageLightboxContext();
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    // タッチデバイス判定（pointer: coarse はタッチスクリーン）
+    // モバイル判定（768px 以下）
     // NOTE: useState の初期値で判定するとハイドレーションミスマッチが起きるため、
     // useEffect でマウント後に判定する
-    const mediaQuery = window.matchMedia("(pointer: coarse)");
-    setIsTouchDevice(mediaQuery.matches);
+    const mediaQuery = window.matchMedia("(max-width: 768px)");
+    setIsMobile(mediaQuery.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
   }, []);
 
-  // モバイル（タッチデバイス）ではライトボックス無効
-  if (isTouchDevice) {
+  // モバイルではライトボックス無効
+  if (isMobile) {
     return <div className={className}>{children}</div>;
   }
 

--- a/src/shared/types/css-modules.d.ts
+++ b/src/shared/types/css-modules.d.ts
@@ -1,5 +1,0 @@
-declare module "*.module.css" {
-  const classes: { readonly [key: string]: string };
-  // biome-ignore lint/style/noDefaultExport: CSS Modules のデフォルトエクスポートを使用する
-  export default classes;
-}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -103,12 +103,19 @@
 }
 
 /* ===== Global Styles ===== */
-html,
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   background-color: var(--color-background-primary);
   color: var(--color-text-primary);
   font-family: var(--font-primary);
   font-size: var(--text-100);
+}
+
+body:has(dialog[open]) {
+  overflow: hidden;
 }
 
 img,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,5 @@
     "**/*.cjs",
     "**/*.mjs"
   ],
-  "exclude": ["node_modules", ".next", "out"]
+  "exclude": ["node_modules", ".next", "out", "storybook-static", "dist"]
 }


### PR DESCRIPTION
## Summary

- 画像をクリックすると拡大表示するライトボックスコンポーネント `ImageLightbox` を追加
- イラスト画像と記事内画像に適用
- デスクトップではクリックで拡大、モバイルでは無効化

## Changes

- `ImageLightbox` コンポーネントの追加（ESCキー/背景クリックで閉じる、prefers-reduced-motion 対応）
- Storybook の viewport 設定を v9 対応に修正
- 不要な CSS Modules 型定義ファイルを削除
- TypeScript の exclude 設定を改善

## Test plan

- [x] Storybook でデスクトップ表示時にボタンになっていることを確認
- [x] Storybook でモバイル表示時に div になっていることを確認
- [x] ダイアログの開閉テストが通ることを確認

closes #202