### PR TITLE
refactor: remove @/ path alias and use relative imports

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,21 +2,21 @@ import type { Preview } from "@storybook/nextjs";
 import { sb } from "storybook/test";
 import { INITIAL_VIEWPORTS } from "storybook/viewport";
 
-import "@/shared/global-settings/global-settings";
+import "../src/shared/global-settings/global-settings";
 import { storyTheme } from "./manager";
 
 // NOTE: Node 利用のモジュールは Storybook で動かないので雑にモックする
 // read-writing などの直接機能で利用しているモジュールで返却値を指定できるようにする
-sb.mock(import("@/contents/writings/reader"));
-sb.mock(import("@/contents/arts/reader"));
-sb.mock(import("@/contents/games/reader"));
-sb.mock(import("@/contents/webapps/reader"));
+sb.mock(import("../src/contents/writings/reader"));
+sb.mock(import("../src/contents/arts/reader"));
+sb.mock(import("../src/contents/games/reader"));
+sb.mock(import("../src/contents/webapps/reader"));
 sb.mock(import("sharp"));
 sb.mock(import("jsdom"));
-sb.mock(import("@/features/writings/writing-reader/read-writing"), {
+sb.mock(import("../src/features/writings/writing-reader/read-writing"), {
   spy: true,
 });
-sb.mock(import("@/features/creation/creation-reader/read-creation"), {
+sb.mock(import("../src/features/creation/creation-reader/read-creation"), {
   spy: true,
 });
 

--- a/scripts/optimize-image.ts
+++ b/scripts/optimize-image.ts
@@ -1,4 +1,4 @@
-import { optimizeImages } from "@/features/writings/writing-detail/optimize-images";
+import { optimizeImages } from "../src/features/writings/writing-detail/optimize-images";
 
 void (async () => {
   console.log("[start] optimize images");

--- a/src/app/creations/[id]/page.tsx
+++ b/src/app/creations/[id]/page.tsx
@@ -1,18 +1,18 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { creationPaths } from "@/entities/creation/paths/creation-paths";
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { CreationDetail } from "@/features/creation/creation-detail/creation-detail";
+import { creationPaths } from "../../../entities/creation/paths/creation-paths";
+import { formatPageTitle } from "../../../entities/page-title/formatter";
+import { CreationDetail } from "../../../features/creation/creation-detail/creation-detail";
 import {
   readCreationById,
   readCreationSummaries,
-} from "@/features/creation/creation-reader/read-creation";
-import { RelatedCreations } from "@/features/creation/related-creations/related-creations";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { FadeIn } from "@/shared/design-system/ui/fade-in/fade-in";
+} from "../../../features/creation/creation-reader/read-creation";
+import { RelatedCreations } from "../../../features/creation/related-creations/related-creations";
+import { HeaderFooterTemplate } from "../../../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../../../shared/design-system/layout/container/container";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { FadeIn } from "../../../shared/design-system/ui/fade-in/fade-in";
 
 export const generateStaticParams = async () => {
   const summaries = await readCreationSummaries();

--- a/src/app/creations/page.tsx
+++ b/src/app/creations/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 
-import { creationPaths } from "@/entities/creation/paths/creation-paths";
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { CreationList } from "@/features/creation/creation-list/creation-list";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
+import { creationPaths } from "../../entities/creation/paths/creation-paths";
+import { formatPageTitle } from "../../entities/page-title/formatter";
+import { CreationList } from "../../features/creation/creation-list/creation-list";
+import { HeaderFooterTemplate } from "../../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../../shared/design-system/layout/container/container";
 
 export const metadata: Metadata = {
   title: formatPageTitle("Creations"),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import { Fira_Code, Noto_Sans_JP, Roboto } from "next/font/google";
 import { Suspense } from "react";
 
-import "@/shared/global-settings/global-settings";
-import { siteConfig } from "@/shared/config/site";
-import { GoogleAnalytics } from "@/shared/google-analytics/google-analytics";
+import "../shared/global-settings/global-settings";
+import { siteConfig } from "../shared/config/site";
+import { GoogleAnalytics } from "../shared/google-analytics/google-analytics";
 
 const notoSansJP = Noto_Sans_JP({ weight: ["400", "700"], subsets: ["latin"] });
 const roboto = Roboto({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,6 @@
-import { PageNotFound } from "@/entities/error-page/page-not-found/page-not-found";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
+import { PageNotFound } from "../entities/error-page/page-not-found/page-not-found";
+import { HeaderFooterTemplate } from "../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../shared/design-system/layout/container/container";
 
 const NotFoundPage = () => {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
-import { AboutMe } from "@/features/home/about-me/about-me";
-import { AboutSite } from "@/features/home/about-site/about-site";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { FadeIn } from "@/shared/design-system/ui/fade-in/fade-in";
+import { AboutMe } from "../features/home/about-me/about-me";
+import { AboutSite } from "../features/home/about-site/about-site";
+import { HeaderFooterTemplate } from "../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../shared/design-system/layout/container/container";
+import { Col } from "../shared/design-system/layout/flex/flex";
+import { FadeIn } from "../shared/design-system/ui/fade-in/fade-in";
 
 const HomePage = () => {
   return (

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H2, H3, P } from "@/shared/design-system/ui/text/text";
+import { formatPageTitle } from "../../entities/page-title/formatter";
+import { HeaderFooterTemplate } from "../../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../../shared/design-system/layout/container/container";
+import { Col } from "../../shared/design-system/layout/flex/flex";
+import { Spacer } from "../../shared/design-system/layout/spacer/spacer";
+import { Link } from "../../shared/design-system/ui/link/link";
+import { H2, H3, P } from "../../shared/design-system/ui/text/text";
 
 export const metadata: Metadata = {
   title: formatPageTitle("Privacy Policy"),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,8 @@
 import type { MetadataRoute } from "next";
 
-import { readGameContents } from "@/contents/games/reader";
-import { readWebappContents } from "@/contents/webapps/reader";
-import { readWritingContents } from "@/contents/writings/reader";
+import { readGameContents } from "../contents/games/reader";
+import { readWebappContents } from "../contents/webapps/reader";
+import { readWritingContents } from "../contents/writings/reader";
 
 const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
   const basePath = "https://syakoo-lab.com";

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
-import { List } from "@/shared/design-system/ui/list/list-with-item";
-import { H2, H3, P } from "@/shared/design-system/ui/text/text";
+import { formatPageTitle } from "../../entities/page-title/formatter";
+import { HeaderFooterTemplate } from "../../features/layout/header-footer-template/header-footer-template";
+import { Container } from "../../shared/design-system/layout/container/container";
+import { Col } from "../../shared/design-system/layout/flex/flex";
+import { Spacer } from "../../shared/design-system/layout/spacer/spacer";
+import { List } from "../../shared/design-system/ui/list/list-with-item";
+import { H2, H3, P } from "../../shared/design-system/ui/text/text";
 
 export const metadata: Metadata = {
   title: formatPageTitle("Privacy Policy"),

--- a/src/app/writings/[id]/page.tsx
+++ b/src/app/writings/[id]/page.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 
-import { readWritingContents } from "@/contents/writings/reader";
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { RelatedWritingsNav } from "@/features/writings/related-writings-nav/related-writings-nav";
-import { WritingDetail } from "@/features/writings/writing-detail/writing-detail";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
+import { readWritingContents } from "../../../contents/writings/reader";
+import { formatPageTitle } from "../../../entities/page-title/formatter";
+import { writingPaths } from "../../../entities/writing/paths/writing-paths";
+import { HeaderFooterTemplate } from "../../../features/layout/header-footer-template/header-footer-template";
+import { RelatedWritingsNav } from "../../../features/writings/related-writings-nav/related-writings-nav";
+import { WritingDetail } from "../../../features/writings/writing-detail/writing-detail";
+import { Container } from "../../../shared/design-system/layout/container/container";
+import { Spacer } from "../../../shared/design-system/layout/spacer/spacer";
 
 export const generateStaticParams = async () => {
   const writingContents = await readWritingContents();

--- a/src/app/writings/page.tsx
+++ b/src/app/writings/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
-import { formatPageTitle } from "@/entities/page-title/formatter";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { HeaderFooterTemplate } from "@/features/layout/header-footer-template/header-footer-template";
-import { WritingList } from "@/features/writings/writing-list/writing-list";
-import { Container } from "@/shared/design-system/layout/container/container";
+import { formatPageTitle } from "../../entities/page-title/formatter";
+import { writingPaths } from "../../entities/writing/paths/writing-paths";
+import { HeaderFooterTemplate } from "../../features/layout/header-footer-template/header-footer-template";
+import { WritingList } from "../../features/writings/writing-list/writing-list";
+import { Container } from "../../shared/design-system/layout/container/container";
 
 export const metadata: Metadata = {
   title: formatPageTitle("Writings"),

--- a/src/contents/about-me/config.ts
+++ b/src/contents/about-me/config.ts
@@ -1,4 +1,4 @@
-import type { AboutMeConfig } from "@/features/home/about-me/types";
+import type { AboutMeConfig } from "../../features/home/about-me/types";
 
 import atcoderImageSrc from "./atcoder.png";
 import githubImageSrc from "./github.png";

--- a/src/entities/creation/creation-card/creation-card.stories.tsx
+++ b/src/entities/creation/creation-card/creation-card.stories.tsx
@@ -4,7 +4,7 @@ import {
   generateDummyCreationGame,
   generateDummyCreationIllust,
   generateDummyCreationWebapp,
-} from "@/entities/creation/models/creation.mocks";
+} from "../models/creation.mocks";
 
 import { CreationCard } from "./creation-card";
 

--- a/src/entities/creation/creation-card/creation-card.tsx
+++ b/src/entities/creation/creation-card/creation-card.tsx
@@ -1,16 +1,15 @@
 import Image from "next/image";
 import type { FC } from "react";
 import { match } from "ts-pattern";
-
-import { creationTypes } from "@/entities/creation/creation-type/creation-type";
+import { Icon } from "../../../shared/design-system/icons/icon";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { Text } from "../../../shared/design-system/ui/text/text";
+import { creationTypes } from "../creation-type/creation-type";
 import type {
   CreationGame,
   CreationIllust,
   CreationWebapp,
-} from "@/entities/creation/models/creation";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { Text } from "@/shared/design-system/ui/text/text";
+} from "../models/creation";
 
 export type CreationCardProps =
   | Pick<CreationIllust, "type" | "title" | "illust">

--- a/src/entities/creation/creation-type/creation-type.ts
+++ b/src/entities/creation/creation-type/creation-type.ts
@@ -1,5 +1,5 @@
-import type { CreationType } from "@/entities/creation/models/creation";
-import type { IconName } from "@/shared/design-system/icons/icon";
+import type { IconName } from "../../../shared/design-system/icons/icon";
+import type { CreationType } from "../models/creation";
 
 export type CreationTypeInfo = {
   label: string;

--- a/src/entities/creation/models/creation.mocks.ts
+++ b/src/entities/creation/models/creation.mocks.ts
@@ -1,4 +1,4 @@
-import { random } from "@/shared/test-utils/random/random";
+import { random } from "../../../shared/test-utils/random/random";
 
 import type {
   CreationBase,

--- a/src/entities/creation/models/creation.ts
+++ b/src/entities/creation/models/creation.ts
@@ -1,4 +1,4 @@
-import type { SerializedMDXContent } from "@/features/mdx/types";
+import type { SerializedMDXContent } from "../../../features/mdx/types";
 
 export type CreationType = "illust" | "game" | "webapp";
 export type Creation = CreationIllust | CreationGame | CreationWebapp;

--- a/src/entities/error-page/page-not-found/page-not-found.tsx
+++ b/src/entities/error-page/page-not-found/page-not-found.tsx
@@ -1,7 +1,7 @@
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H1, Text } from "@/shared/design-system/ui/text/text";
+import { Row } from "../../../shared/design-system/layout/flex/flex";
+import { Spacer } from "../../../shared/design-system/layout/spacer/spacer";
+import { Link } from "../../../shared/design-system/ui/link/link";
+import { H1, Text } from "../../../shared/design-system/ui/text/text";
 
 export const PageNotFound: React.FC = () => {
   return (

--- a/src/entities/page-title/formatter.ts
+++ b/src/entities/page-title/formatter.ts
@@ -1,4 +1,4 @@
-import { siteConfig } from "@/shared/config/site";
+import { siteConfig } from "../../shared/config/site";
 
 /**
  * タイトル用に「`title` - Syakoo Lab」に変換する関数

--- a/src/entities/writing/models/writing.mocks.ts
+++ b/src/entities/writing/models/writing.mocks.ts
@@ -1,4 +1,4 @@
-import { random } from "@/shared/test-utils/random/random";
+import { random } from "../../../shared/test-utils/random/random";
 
 import type { SerializedWriting, WritingHead, WritingType } from "./writing";
 

--- a/src/entities/writing/models/writing.ts
+++ b/src/entities/writing/models/writing.ts
@@ -1,4 +1,4 @@
-import type { SerializedMDXContent } from "@/features/mdx/types";
+import type { SerializedMDXContent } from "../../../features/mdx/types";
 
 export type WritingType = "article" | "note" | "diary";
 

--- a/src/entities/writing/writing-type/writing-type.ts
+++ b/src/entities/writing/writing-type/writing-type.ts
@@ -1,5 +1,5 @@
-import type { WritingType } from "@/entities/writing/models/writing";
-import type { IconName } from "@/shared/design-system/icons/icon";
+import type { IconName } from "../../../shared/design-system/icons/icon";
+import type { WritingType } from "../models/writing";
 
 type WritingTypeConfigItem = {
   type: WritingType;

--- a/src/features/creation/creation-detail/creation-detail.stories.tsx
+++ b/src/features/creation/creation-detail/creation-detail.stories.tsx
@@ -5,8 +5,8 @@ import {
   generateDummyCreationGame,
   generateDummyCreationIllust,
   generateDummyCreationWebapp,
-} from "@/entities/creation/models/creation.mocks";
-import { readCreationById } from "@/features/creation/creation-reader/read-creation";
+} from "../../../entities/creation/models/creation.mocks";
+import { readCreationById } from "../creation-reader/read-creation";
 
 import { CreationDetail } from "./creation-detail";
 

--- a/src/features/creation/creation-detail/creation-detail.tsx
+++ b/src/features/creation/creation-detail/creation-detail.tsx
@@ -1,15 +1,15 @@
 import { notFound } from "next/navigation";
 import { match } from "ts-pattern";
 
-import { creationTypes } from "@/entities/creation/creation-type/creation-type";
-import { readCreationById } from "@/features/creation/creation-reader/read-creation";
-import { resolveMDXContent } from "@/features/mdx/resolver";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Col, Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H2, Text } from "@/shared/design-system/ui/text/text";
-import { cn } from "@/shared/utils/cn/cn";
-import { formatDate } from "@/shared/utils/date";
+import { creationTypes } from "../../../entities/creation/creation-type/creation-type";
+import { Icon } from "../../../shared/design-system/icons/icon";
+import { Col, Row } from "../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../shared/design-system/ui/link/link";
+import { H2, Text } from "../../../shared/design-system/ui/text/text";
+import { cn } from "../../../shared/utils/cn/cn";
+import { formatDate } from "../../../shared/utils/date";
+import { resolveMDXContent } from "../../mdx/resolver";
+import { readCreationById } from "../creation-reader/read-creation";
 import styles from "./creation-detail.module.css";
 
 import { FileView } from "./file-view/file-view";

--- a/src/features/creation/creation-detail/file-view/file-view-ui.tsx
+++ b/src/features/creation/creation-detail/file-view/file-view-ui.tsx
@@ -3,8 +3,8 @@
 import type { FC, PropsWithChildren } from "react";
 import { useState } from "react";
 
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Text } from "@/shared/design-system/ui/text/text";
+import { Icon } from "../../../../shared/design-system/icons/icon";
+import { Text } from "../../../../shared/design-system/ui/text/text";
 
 type Props = PropsWithChildren<{
   fileName: string;

--- a/src/features/creation/creation-detail/public-links/public-links.tsx
+++ b/src/features/creation/creation-detail/public-links/public-links.tsx
@@ -1,8 +1,8 @@
 import type { FC } from "react";
 
-import type { CreationBase } from "@/entities/creation/models/creation";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { BadgeLink } from "@/shared/design-system/ui/badge-link/badge-link";
+import type { CreationBase } from "../../../../entities/creation/models/creation";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { BadgeLink } from "../../../../shared/design-system/ui/badge-link/badge-link";
 
 type PublicLinksProps = Pick<CreationBase, "publicLinks">;
 

--- a/src/features/creation/creation-detail/variant-content/gameplay-screen.tsx
+++ b/src/features/creation/creation-detail/variant-content/gameplay-screen.tsx
@@ -3,8 +3,8 @@
 import type { FC } from "react";
 import { useRef } from "react";
 
-import type { CreationGame } from "@/entities/creation/models/creation";
-import { Icon } from "@/shared/design-system/icons/icon";
+import type { CreationGame } from "../../../../entities/creation/models/creation";
+import { Icon } from "../../../../shared/design-system/icons/icon";
 
 type GameplayScreenProps = Pick<CreationGame, "gameplayScreen" | "title">;
 

--- a/src/features/creation/creation-detail/variant-content/illustration-image.tsx
+++ b/src/features/creation/creation-detail/variant-content/illustration-image.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image";
 import type { FC } from "react";
 
-import type { CreationIllust } from "@/entities/creation/models/creation";
+import type { CreationIllust } from "../../../../entities/creation/models/creation";
 import {
   ImageLightboxRoot,
   ImageLightboxTrigger,
-} from "@/shared/design-system/ui/image-lightbox/image-lightbox";
+} from "../../../../shared/design-system/ui/image-lightbox/image-lightbox";
 
 type IllustrationImageProps = Pick<CreationIllust, "illust" | "title">;
 

--- a/src/features/creation/creation-detail/variant-content/webapp-logo.tsx
+++ b/src/features/creation/creation-detail/variant-content/webapp-logo.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import type { FC } from "react";
 
-import type { CreationWebapp } from "@/entities/creation/models/creation";
+import type { CreationWebapp } from "../../../../entities/creation/models/creation";
 
 type WebappLogoProps = Pick<CreationWebapp, "logo" | "title">;
 

--- a/src/features/creation/creation-list/creation-list.stories.tsx
+++ b/src/features/creation/creation-list/creation-list.stories.tsx
@@ -5,10 +5,10 @@ import {
   generateDummyCreationGame,
   generateDummyCreationIllust,
   generateDummyCreationWebapp,
-} from "@/entities/creation/models/creation.mocks";
-import { readCreationSummaries } from "@/features/creation/creation-reader/read-creation";
-import { random } from "@/shared/test-utils/random/random";
-import { range } from "@/shared/utils/array/range";
+} from "../../../entities/creation/models/creation.mocks";
+import { random } from "../../../shared/test-utils/random/random";
+import { range } from "../../../shared/utils/array/range";
+import { readCreationSummaries } from "../creation-reader/read-creation";
 
 import { CreationList } from "./creation-list";
 

--- a/src/features/creation/creation-list/creation-list.tsx
+++ b/src/features/creation/creation-list/creation-list.tsx
@@ -1,10 +1,10 @@
-import { CreationCard } from "@/entities/creation/creation-card/creation-card";
-import { creationPaths } from "@/entities/creation/paths/creation-paths";
-import { readCreationSummaries } from "@/features/creation/creation-reader/read-creation";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { FadeIn } from "@/shared/design-system/ui/fade-in/fade-in";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H2 } from "@/shared/design-system/ui/text/text";
+import { CreationCard } from "../../../entities/creation/creation-card/creation-card";
+import { creationPaths } from "../../../entities/creation/paths/creation-paths";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { FadeIn } from "../../../shared/design-system/ui/fade-in/fade-in";
+import { Link } from "../../../shared/design-system/ui/link/link";
+import { H2 } from "../../../shared/design-system/ui/text/text";
+import { readCreationSummaries } from "../creation-reader/read-creation";
 
 export const CreationList = async () => {
   const creationSummaries = await readCreationSummaries();

--- a/src/features/creation/creation-reader/read-creation.ts
+++ b/src/features/creation/creation-reader/read-creation.ts
@@ -1,13 +1,13 @@
 import { compareDesc } from "date-fns/esm";
 
-import { readArtContents } from "@/contents/arts/reader";
-import { readGameContents } from "@/contents/games/reader";
-import { readWebappContents } from "@/contents/webapps/reader";
+import { readArtContents } from "../../../contents/arts/reader";
+import { readGameContents } from "../../../contents/games/reader";
+import { readWebappContents } from "../../../contents/webapps/reader";
 import type {
   Creation,
   CreationSummary,
-} from "@/entities/creation/models/creation";
-import { serializeMDXContent } from "@/features/mdx/serializer";
+} from "../../../entities/creation/models/creation";
+import { serializeMDXContent } from "../../mdx/serializer";
 
 import {
   toCreationGameSummary,

--- a/src/features/creation/creation-reader/to-creation-summary.ts
+++ b/src/features/creation/creation-reader/to-creation-summary.ts
@@ -3,14 +3,14 @@ import path from "path";
 
 import probe from "probe-image-size";
 
-import type { ArtContent } from "@/contents/arts/types";
-import type { GameContent } from "@/contents/games/types";
-import type { WebappContent } from "@/contents/webapps/types";
+import type { ArtContent } from "../../../contents/arts/types";
+import type { GameContent } from "../../../contents/games/types";
+import type { WebappContent } from "../../../contents/webapps/types";
 import type {
   CreationGameSummary,
   CreationIllustSummary,
   CreationWebappSummary,
-} from "@/entities/creation/models/creation";
+} from "../../../entities/creation/models/creation";
 
 const publicDir = path.join(process.cwd(), "public");
 

--- a/src/features/creation/related-creations/get-related-creations.test.ts
+++ b/src/features/creation/related-creations/get-related-creations.test.ts
@@ -1,4 +1,4 @@
-import type { CreationType } from "@/entities/creation/models/creation";
+import type { CreationType } from "../../../entities/creation/models/creation";
 
 import { getRelatedCreations } from "./get-related-creations";
 

--- a/src/features/creation/related-creations/get-related-creations.ts
+++ b/src/features/creation/related-creations/get-related-creations.ts
@@ -1,4 +1,4 @@
-import type { Creation } from "@/entities/creation/models/creation";
+import type { Creation } from "../../../entities/creation/models/creation";
 
 /**
  * 関連度を計算するために必要な Creation の属性

--- a/src/features/creation/related-creations/related-creations.stories.tsx
+++ b/src/features/creation/related-creations/related-creations.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { clearAllMocks, mocked } from "storybook/test";
 
-import { generateDummyCreationSummary } from "@/entities/creation/models/creation.mocks";
-import { readCreationSummaries } from "@/features/creation/creation-reader/read-creation";
-import { random } from "@/shared/test-utils/random/random";
-import { range } from "@/shared/utils/array/range";
+import { generateDummyCreationSummary } from "../../../entities/creation/models/creation.mocks";
+import { random } from "../../../shared/test-utils/random/random";
+import { range } from "../../../shared/utils/array/range";
+import { readCreationSummaries } from "../creation-reader/read-creation";
 
 import { RelatedCreations } from "./related-creations";
 

--- a/src/features/creation/related-creations/related-creations.tsx
+++ b/src/features/creation/related-creations/related-creations.tsx
@@ -1,10 +1,10 @@
 import { notFound } from "next/navigation";
 
-import { CreationCard } from "@/entities/creation/creation-card/creation-card";
-import { readCreationSummaries } from "@/features/creation/creation-reader/read-creation";
-import { Col, Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H3 } from "@/shared/design-system/ui/text/text";
+import { CreationCard } from "../../../entities/creation/creation-card/creation-card";
+import { Col, Row } from "../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../shared/design-system/ui/link/link";
+import { H3 } from "../../../shared/design-system/ui/text/text";
+import { readCreationSummaries } from "../creation-reader/read-creation";
 
 import { getRelatedCreations } from "./get-related-creations";
 

--- a/src/features/home/about-me/about-me.tsx
+++ b/src/features/home/about-me/about-me.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 
-import { aboutMeConfig } from "@/contents/about-me/config";
-import { Col, Row } from "@/shared/design-system/layout/flex/flex";
-import { H2, Text } from "@/shared/design-system/ui/text/text";
+import { aboutMeConfig } from "../../../contents/about-me/config";
+import { Col, Row } from "../../../shared/design-system/layout/flex/flex";
+import { H2, Text } from "../../../shared/design-system/ui/text/text";
 
 import { Links } from "./links/links";
 

--- a/src/features/home/about-me/links/links.tsx
+++ b/src/features/home/about-me/links/links.tsx
@@ -1,8 +1,7 @@
 import Image from "next/image";
-
-import type { UserLink } from "@/features/home/about-me/types";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import type { UserLink } from "../types";
 
 type LinksProps = {
   links: UserLink[];

--- a/src/features/home/about-site/about-site.tsx
+++ b/src/features/home/about-site/about-site.tsx
@@ -1,6 +1,6 @@
-import { Center } from "@/shared/design-system/layout/center/center";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { Text } from "@/shared/design-system/ui/text/text";
+import { Center } from "../../../shared/design-system/layout/center/center";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { Text } from "../../../shared/design-system/ui/text/text";
 
 import { SyakooLabLogoWithAnimation } from "./syakoo-lab-logo-with-animation/syakoo-lab-logo-with-animation";
 

--- a/src/features/layout/header-footer-template/footer/footer.tsx
+++ b/src/features/layout/header-footer-template/footer/footer.tsx
@@ -1,8 +1,8 @@
-import { Center } from "@/shared/design-system/layout/center/center";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Text } from "@/shared/design-system/ui/text/text";
+import { Center } from "../../../../shared/design-system/layout/center/center";
+import { Container } from "../../../../shared/design-system/layout/container/container";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { Text } from "../../../../shared/design-system/ui/text/text";
 
 export const Footer: React.FC = () => {
   return (

--- a/src/features/layout/header-footer-template/header-footer-template.tsx
+++ b/src/features/layout/header-footer-template/header-footer-template.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 
-import { Footer } from "@/features/layout/header-footer-template/footer/footer";
-import { Header } from "@/features/layout/header-footer-template/header/header";
+import { Footer } from "./footer/footer";
+import { Header } from "./header/header";
 
 type HeaderFooterTemplateProps = {
   children: React.ReactNode;

--- a/src/features/layout/header-footer-template/header/header.tsx
+++ b/src/features/layout/header-footer-template/header/header.tsx
@@ -3,14 +3,14 @@
 import { usePathname } from "next/navigation";
 import type React from "react";
 
-import { creationPaths } from "@/entities/creation/paths/creation-paths";
-import { SyakooLabText } from "@/entities/syakoo-lab-text/syakoo-lab-text";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { Center } from "@/shared/design-system/layout/center/center";
-import { Container } from "@/shared/design-system/layout/container/container";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Span } from "@/shared/design-system/ui/text/text";
+import { creationPaths } from "../../../../entities/creation/paths/creation-paths";
+import { SyakooLabText } from "../../../../entities/syakoo-lab-text/syakoo-lab-text";
+import { writingPaths } from "../../../../entities/writing/paths/writing-paths";
+import { Center } from "../../../../shared/design-system/layout/center/center";
+import { Container } from "../../../../shared/design-system/layout/container/container";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { Span } from "../../../../shared/design-system/ui/text/text";
 
 export const headerHeightPx = 74;
 

--- a/src/features/mdx/mocks/fixture-mdxcomponent.tsx
+++ b/src/features/mdx/mocks/fixture-mdxcomponent.tsx
@@ -1,4 +1,4 @@
-import type { MDXComponent } from "@/features/mdx/types";
+import type { MDXComponent } from "../types";
 
 export const exampleMDXComponent: MDXComponent = ({ components }) => {
   const H2 = components?.h2 ?? "h2";

--- a/src/features/mdx/plugins/mermaid/mermaid-plugin.ts
+++ b/src/features/mdx/plugins/mermaid/mermaid-plugin.ts
@@ -1,4 +1,4 @@
-import type { MDXCustomTextPlugin } from "@/features/mdx/types";
+import type { MDXCustomTextPlugin } from "../../types";
 
 /**
  * mermaid のよくある記法を評価できるように変更する関数

--- a/src/features/mdx/plugins/mermaid/use-mermaid.ts
+++ b/src/features/mdx/plugins/mermaid/use-mermaid.ts
@@ -1,6 +1,6 @@
 import mermaid from "mermaid";
 
-import { useMount } from "@/shared/utils/use-mount/use-mount";
+import { useMount } from "../../../../shared/utils/use-mount/use-mount";
 
 // Mermaid は CSS 変数を受け付けないため、直接色の値を指定
 const colors = {

--- a/src/features/mdx/plugins/twitter/use-twitter.ts
+++ b/src/features/mdx/plugins/twitter/use-twitter.ts
@@ -1,4 +1,4 @@
-import { useMount } from "@/shared/utils/use-mount/use-mount";
+import { useMount } from "../../../../shared/utils/use-mount/use-mount";
 
 export const useTwitter = () => {
   useMount(() => {

--- a/src/features/writings/related-writings-nav/find-related-writing-heads.ts
+++ b/src/features/writings/related-writings-nav/find-related-writing-heads.ts
@@ -1,7 +1,7 @@
 import { compareDesc } from "date-fns";
 
-import type { WritingHead } from "@/entities/writing/models/writing";
-import { readWritingHeads } from "@/features/writings/writing-reader/read-writing";
+import type { WritingHead } from "../../../entities/writing/models/writing";
+import { readWritingHeads } from "../writing-reader/read-writing";
 
 const writingRelatedScore =
   (originalTags: WritingHead["tags"]) => (targetTags: WritingHead["tags"]) => {

--- a/src/features/writings/related-writings-nav/related-writings-nav.stories.tsx
+++ b/src/features/writings/related-writings-nav/related-writings-nav.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { clearAllMocks, mocked } from "storybook/test";
 
-import { generateDummyWritingHead } from "@/entities/writing/models/writing.mocks";
-import { readWritingHeads } from "@/features/writings/writing-reader/read-writing";
-import { random } from "@/shared/test-utils/random/random";
-import { range } from "@/shared/utils/array/range";
+import { generateDummyWritingHead } from "../../../entities/writing/models/writing.mocks";
+import { random } from "../../../shared/test-utils/random/random";
+import { range } from "../../../shared/utils/array/range";
+import { readWritingHeads } from "../writing-reader/read-writing";
 
 import { RelatedWritingsNav } from "./related-writings-nav";
 

--- a/src/features/writings/related-writings-nav/related-writings-nav.tsx
+++ b/src/features/writings/related-writings-nav/related-writings-nav.tsx
@@ -1,5 +1,5 @@
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { H3 } from "@/shared/design-system/ui/text/text";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { H3 } from "../../../shared/design-system/ui/text/text";
 
 import { findRelatedWritingHeads } from "./find-related-writing-heads";
 import { WritingLink } from "./writing-link/writing-link";

--- a/src/features/writings/related-writings-nav/writing-link/writing-link.tsx
+++ b/src/features/writings/related-writings-nav/writing-link/writing-link.tsx
@@ -1,10 +1,10 @@
-import type { WritingHead } from "@/entities/writing/models/writing";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { getWritingTypeConfig } from "@/entities/writing/writing-type/writing-type";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Col, Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H4, Span } from "@/shared/design-system/ui/text/text";
+import type { WritingHead } from "../../../../entities/writing/models/writing";
+import { writingPaths } from "../../../../entities/writing/paths/writing-paths";
+import { getWritingTypeConfig } from "../../../../entities/writing/writing-type/writing-type";
+import { Icon } from "../../../../shared/design-system/icons/icon";
+import { Col, Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { H4, Span } from "../../../../shared/design-system/ui/text/text";
 
 type WritingLinkProps = {
   head: WritingHead;

--- a/src/features/writings/writing-detail/mdx/book-view/book-view.tsx
+++ b/src/features/writings/writing-detail/mdx/book-view/book-view.tsx
@@ -1,6 +1,6 @@
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Text } from "@/shared/design-system/ui/text/text";
+import { Row } from "../../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../../shared/design-system/ui/link/link";
+import { Text } from "../../../../../shared/design-system/ui/text/text";
 
 type BookViewProps = {
   title: string;

--- a/src/features/writings/writing-detail/mdx/chat/chat.tsx
+++ b/src/features/writings/writing-detail/mdx/chat/chat.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-import { cn } from "@/shared/utils/cn/cn";
+import { cn } from "../../../../../shared/utils/cn/cn";
 import fuyu1 from "./assets/fuyu1.png";
 import fuyu2 from "./assets/fuyu2.png";
 import fuyu3 from "./assets/fuyu3.png";

--- a/src/features/writings/writing-detail/mdx/choices/choices.tsx
+++ b/src/features/writings/writing-detail/mdx/choices/choices.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { cn } from "@/shared/utils/cn/cn";
+import { cn } from "../../../../../shared/utils/cn/cn";
 
 import styles from "./choices.module.css";
 

--- a/src/features/writings/writing-detail/mdx/geometry/geometry.stories.tsx
+++ b/src/features/writings/writing-detail/mdx/geometry/geometry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn, StoryObj } from "@storybook/nextjs";
 
-import { Figure } from "@/features/writings/writing-detail/mdx/figure/figure-with-caption";
+import { Figure } from "../figure/figure-with-caption";
 
 import {
   GCircle,

--- a/src/features/writings/writing-detail/mdx/geometry/point.tsx
+++ b/src/features/writings/writing-detail/mdx/geometry/point.tsx
@@ -1,4 +1,4 @@
-import { useMount } from "@/shared/utils/use-mount/use-mount";
+import { useMount } from "../../../../../shared/utils/use-mount/use-mount";
 import {
   type ColorKey,
   type PointId,

--- a/src/features/writings/writing-detail/mdx/image/image-plugin.ts
+++ b/src/features/writings/writing-detail/mdx/image/image-plugin.ts
@@ -1,6 +1,6 @@
 import sharp from "sharp";
 
-import type { MDXCustomTextPlugin } from "@/features/mdx/types";
+import type { MDXCustomTextPlugin } from "../../../../mdx/types";
 
 // replace の async 版
 const asyncReplace = async (

--- a/src/features/writings/writing-detail/mdx/image/image.tsx
+++ b/src/features/writings/writing-detail/mdx/image/image.tsx
@@ -1,7 +1,7 @@
 import {
   ImageLightboxRoot,
   ImageLightboxTrigger,
-} from "@/shared/design-system/ui/image-lightbox/image-lightbox";
+} from "../../../../../shared/design-system/ui/image-lightbox/image-lightbox";
 
 type ImageProps = {
   caption?: string;

--- a/src/features/writings/writing-detail/mdx/link-card/link-card.tsx
+++ b/src/features/writings/writing-detail/mdx/link-card/link-card.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Text } from "@/shared/design-system/ui/text/text";
+import { Row } from "../../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../../shared/design-system/ui/link/link";
+import { Text } from "../../../../../shared/design-system/ui/text/text";
 
 export type LinkCardProps = {
   imgSrc: string;

--- a/src/features/writings/writing-detail/mdx/link-card/markup-link-card-plugin.ts
+++ b/src/features/writings/writing-detail/mdx/link-card/markup-link-card-plugin.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom";
 
-import type { MDXCustomTextPlugin } from "@/features/mdx/types";
+import type { MDXCustomTextPlugin } from "../../../../mdx/types";
 
 import type { LinkCardProps } from "./link-card";
 

--- a/src/features/writings/writing-detail/mdx/note/note.tsx
+++ b/src/features/writings/writing-detail/mdx/note/note.tsx
@@ -1,5 +1,5 @@
-import { Icon } from "@/shared/design-system/icons/icon";
-import { cn } from "@/shared/utils/cn/cn";
+import { Icon } from "../../../../../shared/design-system/icons/icon";
+import { cn } from "../../../../../shared/utils/cn/cn";
 
 import styles from "./note.module.css";
 

--- a/src/features/writings/writing-detail/mdx/plugins.ts
+++ b/src/features/writings/writing-detail/mdx/plugins.ts
@@ -1,4 +1,4 @@
-import type { MDXCustomTextPlugin } from "@/features/mdx/types";
+import type { MDXCustomTextPlugin } from "../../../mdx/types";
 
 import { imagePlugin } from "./image/image-plugin";
 import { markupLinkCardPlugin } from "./link-card/markup-link-card-plugin";

--- a/src/features/writings/writing-detail/mdx/section-title/markup-section-title-plugin.ts
+++ b/src/features/writings/writing-detail/mdx/section-title/markup-section-title-plugin.ts
@@ -1,9 +1,9 @@
 import { JSDOM } from "jsdom";
 import React from "react";
 
-import { resolveMDXContent } from "@/features/mdx/resolver";
-import { serializeMDXContent } from "@/features/mdx/serializer";
-import type { MDXCustomTextPlugin } from "@/features/mdx/types";
+import { resolveMDXContent } from "../../../../mdx/resolver";
+import { serializeMDXContent } from "../../../../mdx/serializer";
+import type { MDXCustomTextPlugin } from "../../../../mdx/types";
 
 /**
  * 見出し2, 3 (`## xxx`, `### xxx`) を Section, SubSection に変換するプラグイン

--- a/src/features/writings/writing-detail/mdx/section-title/section-title.tsx
+++ b/src/features/writings/writing-detail/mdx/section-title/section-title.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@/shared/design-system/ui/link/link";
+import { Link } from "../../../../../shared/design-system/ui/link/link";
 
 import styles from "./section-title.module.css";
 

--- a/src/features/writings/writing-detail/mdx/section-title/sub-section-title.tsx
+++ b/src/features/writings/writing-detail/mdx/section-title/sub-section-title.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link } from "@/shared/design-system/ui/link/link";
+import { Link } from "../../../../../shared/design-system/ui/link/link";
 
 type SubSectionTitleProps = {
   children: React.ReactNode;

--- a/src/features/writings/writing-detail/toc/toc.tsx
+++ b/src/features/writings/writing-detail/toc/toc.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from "react";
 
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Span, Text } from "@/shared/design-system/ui/text/text";
-import { useMount } from "@/shared/utils/use-mount/use-mount";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { Span, Text } from "../../../../shared/design-system/ui/text/text";
+import { useMount } from "../../../../shared/utils/use-mount/use-mount";
 
 type TOCItem = {
   label: string;

--- a/src/features/writings/writing-detail/writing-detail.stories.tsx
+++ b/src/features/writings/writing-detail/writing-detail.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { clearAllMocks, mocked } from "storybook/test";
 
-import { generateDummySerializedWriting } from "@/entities/writing/models/writing.mocks";
-import { readWritingById } from "@/features/writings/writing-reader/read-writing";
+import { generateDummySerializedWriting } from "../../../entities/writing/models/writing.mocks";
+import { readWritingById } from "../writing-reader/read-writing";
 
 import { WritingDetail } from "./writing-detail";
 

--- a/src/features/writings/writing-detail/writing-detail.tsx
+++ b/src/features/writings/writing-detail/writing-detail.tsx
@@ -1,9 +1,8 @@
 import { differenceInYears } from "date-fns";
 import { notFound } from "next/navigation";
-
-import { readWritingById } from "@/features/writings/writing-reader/read-writing";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
-import { FadeIn } from "@/shared/design-system/ui/fade-in/fade-in";
+import { Spacer } from "../../../shared/design-system/layout/spacer/spacer";
+import { FadeIn } from "../../../shared/design-system/ui/fade-in/fade-in";
+import { readWritingById } from "../writing-reader/read-writing";
 
 import { Note } from "./mdx/note/note";
 import { TOC } from "./toc/toc";

--- a/src/features/writings/writing-detail/writing-header/writing-header.tsx
+++ b/src/features/writings/writing-detail/writing-header/writing-header.tsx
@@ -1,10 +1,10 @@
-import type { WritingHead } from "@/entities/writing/models/writing";
-import { getWritingTypeConfig } from "@/entities/writing/writing-type/writing-type";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Spacer } from "@/shared/design-system/layout/spacer/spacer";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H1, Span, Text } from "@/shared/design-system/ui/text/text";
+import type { WritingHead } from "../../../../entities/writing/models/writing";
+import { getWritingTypeConfig } from "../../../../entities/writing/writing-type/writing-type";
+import { Icon } from "../../../../shared/design-system/icons/icon";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Spacer } from "../../../../shared/design-system/layout/spacer/spacer";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { H1, Span, Text } from "../../../../shared/design-system/ui/text/text";
 
 type WritingHeaderProps = {
   head: WritingHead;

--- a/src/features/writings/writing-detail/writing-mdx-content.tsx
+++ b/src/features/writings/writing-detail/writing-mdx-content.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type { SerializedWriting } from "@/entities/writing/models/writing";
-import { useMermaid } from "@/features/mdx/plugins/mermaid/use-mermaid";
-import { useTwitter } from "@/features/mdx/plugins/twitter/use-twitter";
-import { resolveMDXContent } from "@/features/mdx/resolver";
-import { Link } from "@/shared/design-system/ui/link/link";
+import type { SerializedWriting } from "../../../entities/writing/models/writing";
+import { Link } from "../../../shared/design-system/ui/link/link";
+import { useMermaid } from "../../mdx/plugins/mermaid/use-mermaid";
+import { useTwitter } from "../../mdx/plugins/twitter/use-twitter";
+import { resolveMDXContent } from "../../mdx/resolver";
 
 import { mdxComponents } from "./mdx/mdx-components";
 

--- a/src/features/writings/writing-detail/writing-type-description/writing-type-description.tsx
+++ b/src/features/writings/writing-detail/writing-type-description/writing-type-description.tsx
@@ -1,8 +1,8 @@
-import type { WritingType } from "@/entities/writing/models/writing";
-import { getWritingTypeConfig } from "@/entities/writing/writing-type/writing-type";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Col, Row } from "@/shared/design-system/layout/flex/flex";
-import { P, Text } from "@/shared/design-system/ui/text/text";
+import type { WritingType } from "../../../../entities/writing/models/writing";
+import { getWritingTypeConfig } from "../../../../entities/writing/writing-type/writing-type";
+import { Icon } from "../../../../shared/design-system/icons/icon";
+import { Col, Row } from "../../../../shared/design-system/layout/flex/flex";
+import { P, Text } from "../../../../shared/design-system/ui/text/text";
 
 type WritingTypeDescriptionProps = {
   type: WritingType;

--- a/src/features/writings/writing-list/_shared/writing-list-type.ts
+++ b/src/features/writings/writing-list/_shared/writing-list-type.ts
@@ -1,8 +1,8 @@
 import { useSearchParams } from "next/navigation";
 
-import type { WritingType } from "@/entities/writing/models/writing";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { writingTypes } from "@/entities/writing/writing-type/writing-type";
+import type { WritingType } from "../../../../entities/writing/models/writing";
+import { writingPaths } from "../../../../entities/writing/paths/writing-paths";
+import { writingTypes } from "../../../../entities/writing/writing-type/writing-type";
 
 export type WritingListType = WritingType | "all";
 

--- a/src/features/writings/writing-list/writing-block/writing-block.stories.tsx
+++ b/src/features/writings/writing-list/writing-block/writing-block.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
-import type { WritingHead } from "@/entities/writing/models/writing";
+import type { WritingHead } from "../../../../entities/writing/models/writing";
 
 import { WritingBlock } from "./writing-block";
 

--- a/src/features/writings/writing-list/writing-block/writing-block.tsx
+++ b/src/features/writings/writing-list/writing-block/writing-block.tsx
@@ -1,10 +1,10 @@
-import type { WritingHead } from "@/entities/writing/models/writing";
-import { writingPaths } from "@/entities/writing/paths/writing-paths";
-import { getWritingTypeConfig } from "@/entities/writing/writing-type/writing-type";
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { H3, Text } from "@/shared/design-system/ui/text/text";
+import type { WritingHead } from "../../../../entities/writing/models/writing";
+import { writingPaths } from "../../../../entities/writing/paths/writing-paths";
+import { getWritingTypeConfig } from "../../../../entities/writing/writing-type/writing-type";
+import { Icon } from "../../../../shared/design-system/icons/icon";
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { H3, Text } from "../../../../shared/design-system/ui/text/text";
 
 type WritingBlockProps = {
   head: WritingHead;

--- a/src/features/writings/writing-list/writing-list-view.tsx
+++ b/src/features/writings/writing-list/writing-list-view.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type { WritingHead } from "@/entities/writing/models/writing";
-import { writingTypeConfig } from "@/entities/writing/writing-type/writing-type";
-import { Col } from "@/shared/design-system/layout/flex/flex";
-import { FadeIn } from "@/shared/design-system/ui/fade-in/fade-in";
-import { H2, Text } from "@/shared/design-system/ui/text/text";
+import type { WritingHead } from "../../../entities/writing/models/writing";
+import { writingTypeConfig } from "../../../entities/writing/writing-type/writing-type";
+import { Col } from "../../../shared/design-system/layout/flex/flex";
+import { FadeIn } from "../../../shared/design-system/ui/fade-in/fade-in";
+import { H2, Text } from "../../../shared/design-system/ui/text/text";
 
 import { useGetWritingListType } from "./_shared/writing-list-type";
 import { WritingBlock } from "./writing-block/writing-block";

--- a/src/features/writings/writing-list/writing-list.stories.tsx
+++ b/src/features/writings/writing-list/writing-list.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { clearAllMocks, mocked } from "storybook/test";
 
-import { generateDummyWritingHead } from "@/entities/writing/models/writing.mocks";
-import { readWritingHeads } from "@/features/writings/writing-reader/read-writing";
-import { random } from "@/shared/test-utils/random/random";
-import { range } from "@/shared/utils/array/range";
+import { generateDummyWritingHead } from "../../../entities/writing/models/writing.mocks";
+import { random } from "../../../shared/test-utils/random/random";
+import { range } from "../../../shared/utils/array/range";
+import { readWritingHeads } from "../writing-reader/read-writing";
 
 import { WritingList } from "./writing-list";
 

--- a/src/features/writings/writing-list/writing-list.tsx
+++ b/src/features/writings/writing-list/writing-list.tsx
@@ -1,4 +1,4 @@
-import { readWritingHeads } from "@/features/writings/writing-reader/read-writing";
+import { readWritingHeads } from "../writing-reader/read-writing";
 
 import { WritingListView } from "./writing-list-view";
 

--- a/src/features/writings/writing-list/writing-tab/writing-tab.tsx
+++ b/src/features/writings/writing-list/writing-tab/writing-tab.tsx
@@ -1,10 +1,10 @@
+import { Row } from "../../../../shared/design-system/layout/flex/flex";
+import { Link } from "../../../../shared/design-system/ui/link/link";
+import { cn } from "../../../../shared/utils/cn/cn";
 import {
   type WritingListType,
   writingListTypePath,
-} from "@/features/writings/writing-list/_shared/writing-list-type";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { cn } from "@/shared/utils/cn/cn";
+} from "../_shared/writing-list-type";
 
 type WritingTabProps = {
   selectedType: WritingListType;

--- a/src/features/writings/writing-reader/head-resolver.ts
+++ b/src/features/writings/writing-reader/head-resolver.ts
@@ -1,5 +1,5 @@
-import type { WritingContentFrontMatter } from "@/contents/writings/types";
-import type { WritingHead } from "@/entities/writing/models/writing";
+import type { WritingContentFrontMatter } from "../../../contents/writings/types";
+import type { WritingHead } from "../../../entities/writing/models/writing";
 
 /**
  * 文書のヘッダーコンテンツを変換する関数

--- a/src/features/writings/writing-reader/read-writing.ts
+++ b/src/features/writings/writing-reader/read-writing.ts
@@ -1,13 +1,13 @@
 import { compareDesc } from "date-fns";
 
-import { readWritingContents } from "@/contents/writings/reader";
+import { readWritingContents } from "../../../contents/writings/reader";
 import type {
   SerializedWriting,
   WritingHead,
-} from "@/entities/writing/models/writing";
-import { markupMermaid } from "@/features/mdx/plugins/mermaid/mermaid-plugin";
-import { serializeMDXContent } from "@/features/mdx/serializer";
-import { mdxPlugins } from "@/features/writings/writing-detail/mdx/plugins";
+} from "../../../entities/writing/models/writing";
+import { markupMermaid } from "../../mdx/plugins/mermaid/mermaid-plugin";
+import { serializeMDXContent } from "../../mdx/serializer";
+import { mdxPlugins } from "../writing-detail/mdx/plugins";
 
 import { resolveWritingHead } from "./head-resolver";
 

--- a/src/shared/design-system/layout/center/center.tsx
+++ b/src/shared/design-system/layout/center/center.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { PolymorphicComponent } from "@/shared/utils/polymorphic-component/polymorphic-component";
+import { PolymorphicComponent } from "../../../utils/polymorphic-component/polymorphic-component";
 
 type CenterProps = {
   as?: keyof JSX.IntrinsicElements;

--- a/src/shared/design-system/layout/container/container.tsx
+++ b/src/shared/design-system/layout/container/container.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { PolymorphicComponent } from "@/shared/utils/polymorphic-component/polymorphic-component";
+import { PolymorphicComponent } from "../../../utils/polymorphic-component/polymorphic-component";
 
 import {
   type ContainerStyleVariants,

--- a/src/shared/design-system/layout/flex/flex.tsx
+++ b/src/shared/design-system/layout/flex/flex.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { PolymorphicComponent } from "@/shared/utils/polymorphic-component/polymorphic-component";
+import { PolymorphicComponent } from "../../../utils/polymorphic-component/polymorphic-component";
 
 import {
   type FlexItemStyleVariants,

--- a/src/shared/design-system/ui/badge-link/badge-link.tsx
+++ b/src/shared/design-system/ui/badge-link/badge-link.tsx
@@ -1,7 +1,7 @@
-import { Icon } from "@/shared/design-system/icons/icon";
-import { Row } from "@/shared/design-system/layout/flex/flex";
-import { Link } from "@/shared/design-system/ui/link/link";
-import { Span } from "@/shared/design-system/ui/text/text";
+import { Icon } from "../../icons/icon";
+import { Row } from "../../layout/flex/flex";
+import { Link } from "../link/link";
+import { Span } from "../text/text";
 
 export type BadgeLinkProps = {
   href: string;

--- a/src/shared/design-system/ui/fade-in/fade-in.tsx
+++ b/src/shared/design-system/ui/fade-in/fade-in.tsx
@@ -1,4 +1,4 @@
-import { PolymorphicComponent } from "@/shared/utils/polymorphic-component/polymorphic-component";
+import { PolymorphicComponent } from "../../../utils/polymorphic-component/polymorphic-component";
 
 type FadeInProps = {
   children: React.ReactNode;

--- a/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
+++ b/src/shared/design-system/ui/image-lightbox/image-lightbox.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { cn } from "@/shared/utils/cn/cn";
+import { cn } from "../../../utils/cn/cn";
 
 import styles from "./image-lightbox.module.css";
 

--- a/src/shared/design-system/ui/text/text.tsx
+++ b/src/shared/design-system/ui/text/text.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 
-import { PolymorphicComponent } from "@/shared/utils/polymorphic-component/polymorphic-component";
+import { PolymorphicComponent } from "../../../utils/polymorphic-component/polymorphic-component";
 
 import { type TextStyleVariants, textStyle } from "./text.styles";
 

--- a/src/shared/global-settings/global-settings.ts
+++ b/src/shared/global-settings/global-settings.ts
@@ -1,1 +1,1 @@
-import "@/styles/globals.css";
+import "../../styles/globals.css";

--- a/src/shared/google-analytics/core.ts
+++ b/src/shared/google-analytics/core.ts
@@ -1,4 +1,4 @@
-import { env } from "env";
+import { env } from "../../../env";
 
 declare global {
   // biome-ignore lint/style/useConsistentTypeDefinitions: グローバル型拡張には interface が必要

--- a/src/shared/test-utils/vitest-setup.ts
+++ b/src/shared/test-utils/vitest-setup.ts
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 
-import { exampleMDXComponent } from "@/features/mdx/mocks/fixture-mdxcomponent";
+import { exampleMDXComponent } from "../../features/mdx/mocks/fixture-mdxcomponent";
 
 import { loadEnv } from "./nextjs/env";
 

--- a/src/shared/utils/async/_base/use-base-async-fn.ts
+++ b/src/shared/utils/async/_base/use-base-async-fn.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useMountedState } from "@/shared/utils/use-mounted-state/use-mounted-state";
+import { useMountedState } from "../../use-mounted-state/use-mounted-state";
 
 import type {
   AsyncStateError,

--- a/src/shared/utils/async/use-init-async.ts
+++ b/src/shared/utils/async/use-init-async.ts
@@ -1,4 +1,4 @@
-import { useMount } from "@/shared/utils/use-mount/use-mount";
+import { useMount } from "../use-mount/use-mount";
 
 import type {
   AsyncStateError,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,6 @@
     "resolveJsonModule": true,
     "jsx": "preserve",
     "jsxImportSource": "react",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "lib": ["dom", "dom.iterable", "esnext"],
     "types": ["vitest/globals"],
     "incremental": true,


### PR DESCRIPTION
## Summary

- `@/` エイリアスを全て相対パスに変換（261箇所）
- `tsconfig.json` から `paths` と `baseUrl` を削除
- Storybook の `sb.mock` も相対パスに更新

## Why

Storybook 10 では `sb.mock` が TypeScript の path alias (`@/`) を解決できず、`MODULE_NOT_FOUND` エラーが発生する。相対パスに統一することでこの問題を回避し、Storybook 10 へのアップグレードを可能にする。

## Test plan

- [x] Next.js ビルド通過
- [x] vitest 全テスト通過
- [x] Storybook ビルド通過
- [x] Storybook テスト通過
- [x] lint 通過