### PR TITLE
chore: SEO 設定の改善

### DIFF
--- a/src/app/creations/page.tsx
+++ b/src/app/creations/page.tsx
@@ -8,9 +8,6 @@ import { Container } from "../../shared/design-system/layout/container/container
 
 export const metadata: Metadata = {
   title: formatPageTitle("Creations"),
-  robots: {
-    index: false,
-  },
   openGraph: {
     type: "website",
     images: "/logo.png",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+const robots = (): MetadataRoute.Robots => {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+      // AI クローラーには画像・アセットのみブロック
+      {
+        userAgent: [
+          "GPTBot", // OpenAI
+          "ChatGPT-User", // OpenAI (ChatGPT browsing)
+          "Google-Extended", // Google AI
+          "CCBot", // Common Crawl
+          "anthropic-ai", // Anthropic
+          "Claude-Web", // Anthropic
+          "Bytespider", // ByteDance
+          "cohere-ai", // Cohere
+        ],
+        disallow: ["/img/", "/assets/"],
+      },
+    ],
+    sitemap: "https://syakoo-lab.com/sitemap.xml",
+  };
+};
+
+// biome-ignore lint/style/noDefaultExport: デフォルトエクスポートを使用する
+export default robots;

--- a/src/app/writings/page.tsx
+++ b/src/app/writings/page.tsx
@@ -9,9 +9,6 @@ import { Container } from "../../shared/design-system/layout/container/container
 
 export const metadata: Metadata = {
   title: formatPageTitle("Writings"),
-  robots: {
-    index: false,
-  },
   openGraph: {
     type: "website",
     images: "/logo.png",


### PR DESCRIPTION
## Summary
  - robots.ts を追加し、AI クローラーから画像・アセットをブロック
  - 一覧ページ（/creations, /writings）の noindex を削除
  - sitemap の場所を robots.txt で明示
  ## 背景
  /creations/escape-from-the-workroom が「検出 - インデックス未登録」だったため、SEO 設定を見直し