### PR TITLE
refactor(mdx): SerializedMDXContent を entities へ移設して依存方向を整理

### DIFF
--- a/src/entities/creation/models/creation.ts
+++ b/src/entities/creation/models/creation.ts
@@ -1,4 +1,4 @@
-import type { SerializedMDXContent } from "../../../features/mdx/types";
+import type { SerializedMDXContent } from "../../mdx-content/models/mdx-content";
 
 export type CreationType = "illust" | "game" | "webapp";
 export type Creation = CreationIllust | CreationGame | CreationWebapp;

--- a/src/entities/mdx-content/models/mdx-content.ts
+++ b/src/entities/mdx-content/models/mdx-content.ts
@@ -1,0 +1,4 @@
+export type SerializedMDXContent = {
+  type: "serialized";
+  data: string;
+};

--- a/src/entities/writing/models/writing.ts
+++ b/src/entities/writing/models/writing.ts
@@ -1,4 +1,4 @@
-import type { SerializedMDXContent } from "../../../features/mdx/types";
+import type { SerializedMDXContent } from "../../mdx-content/models/mdx-content";
 
 export type WritingType = "article" | "note" | "diary";
 

--- a/src/features/mdx/resolver.ts
+++ b/src/features/mdx/resolver.ts
@@ -1,11 +1,8 @@
 import { runSync } from "@mdx-js/mdx";
 import * as runtime from "react/jsx-runtime";
 
-import type {
-  MDXComponent,
-  ResolvedMDXContent,
-  SerializedMDXContent,
-} from "./types";
+import type { SerializedMDXContent } from "../../entities/mdx-content/models/mdx-content";
+import type { MDXComponent, ResolvedMDXContent } from "./types";
 
 /**
  * シリアライズされた MDX をコンポーネントに解決する関数

--- a/src/features/mdx/serializer.ts
+++ b/src/features/mdx/serializer.ts
@@ -3,7 +3,8 @@ import rehypeKatex from "rehype-katex";
 import rehypePrettyCode from "rehype-pretty-code";
 import remarkMath from "remark-math";
 
-import type { MDXCustomTextPlugin, SerializedMDXContent } from "./types";
+import type { SerializedMDXContent } from "../../entities/mdx-content/models/mdx-content";
+import type { MDXCustomTextPlugin } from "./types";
 
 /**
  * MDX 本文をシリアライズする関数

--- a/src/features/mdx/types.ts
+++ b/src/features/mdx/types.ts
@@ -8,10 +8,6 @@ export type MDXComponent = React.FC<{
   components?: Record<string, React.FC<any>>;
 }>;
 
-export type SerializedMDXContent = {
-  type: "serialized";
-  data: string;
-};
 export type ResolvedMDXContent = {
   type: "resolved";
   data: MDXComponent;


### PR DESCRIPTION
## Summary
- `SerializedMDXContent` を `src/entities/mdx-content/models/mdx-content.ts` に移設し、`entities` 側の契約型として管理
- `entities/writing` と `entities/creation` の参照を `features/mdx/types` から新しい entities モジュールへ変更
- `features/mdx` は `MDXCustomTextPlugin` / `MDXComponent` / `ResolvedMDXContent` を維持しつつ、serializer/resolver で `SerializedMDXContent` を entities から参照

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm test -- --run`

Made with [Cursor](https://cursor.com)