### PR TITLE
biome lint の warning を解消

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/features/writings/writing-detail/mdx/image/image-plugin.ts
+++ b/src/features/writings/writing-detail/mdx/image/image-plugin.ts
@@ -32,7 +32,7 @@ export const imagePlugin: MDXCustomTextPlugin = async (mdxText) => {
   return await asyncReplace(mdxText, pattern, async ([match, attributes]) => {
     const srcMatch = attributes.match(/src={?["'](.*?)["']/);
     // NOTE: src がマッチしない或いはこのサイトのものではない場合はそのまま返却する
-    if (!srcMatch || !srcMatch[1].startsWith("/")) {
+    if (!srcMatch?.[1].startsWith("/")) {
       return match;
     }
     const imageUrl = `${process.cwd()}/public${srcMatch[1]}`;

--- a/src/shared/utils/async/use-async-fn.ts
+++ b/src/shared/utils/async/use-async-fn.ts
@@ -59,8 +59,7 @@ export const useAsyncFn = <AsyncFn extends AsyncFnBase>(
 ) => {
   const [state, callback] = useBaseAsyncFn(asyncFn, initialState);
 
-  // NOTE: asyncFn のラッパー関数であるため asyncFn の deps を入れる
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: asyncFn のラッパー関数であるため呼び出し側の deps で制御する
   const memorizedCallback = useCallback(callback, [...deps]);
 
   return [state, memorizedCallback] as const;

--- a/src/shared/utils/async/use-async-fn.ts
+++ b/src/shared/utils/async/use-async-fn.ts
@@ -60,7 +60,7 @@ export const useAsyncFn = <AsyncFn extends AsyncFnBase>(
   const [state, callback] = useBaseAsyncFn(asyncFn, initialState);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: asyncFn のラッパー関数であるため呼び出し側の deps で制御する
-  const memorizedCallback = useCallback(callback, [...deps]);
+  const memorizedCallback = useCallback(callback, deps);
 
   return [state, memorizedCallback] as const;
 };

--- a/src/shared/utils/use-mount/use-mount.tsx
+++ b/src/shared/utils/use-mount/use-mount.tsx
@@ -2,7 +2,6 @@ import type { EffectCallback } from "react";
 import { useEffect } from "react";
 
 export const useMount = (callback: EffectCallback) => {
-  // NOTE: 一度のみ
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: マウント時に一度だけ実行する
   useEffect(callback, []);
 };


### PR DESCRIPTION
## 課題

`biome check .` で 3 件の warning と 1 件の info が出ていた。

## 解決法

- **biome.jsonc**: スキーマバージョンを CLI (2.4.13) に合わせて更新
- **image-plugin.ts**: `!srcMatch || !srcMatch[1].startsWith(...)` を optional chain (`srcMatch?.[1].startsWith(...)`) に書き換え
- **use-async-fn.ts / use-mount.tsx**: eslint から biome に移行した際の残骸である `eslint-disable-next-line` コメントを `biome-ignore` に置き換え

## 影響・懸念

なし

Made with [Cursor](https://cursor.com)