### PR TITLE
Standardize agent-facing docs and communication to English

### DIFF
--- a/.cursor/agents/create-github-issue.md
+++ b/.cursor/agents/create-github-issue.md
@@ -25,7 +25,7 @@ Follow `.cursor/skills/create-github-issue` for the same procedure.
 
 ## Feature request (`feature_request.yml`)
 
-Template UI is Japanese. **Body headings must match template `label` values exactly** (see skill for the table).
+**Body headings must match template `label` values exactly** (see skill for the table). Write section prose in English unless the user requests another language.
 
 | Item | Rule |
 |------|------|
@@ -36,21 +36,21 @@ Template UI is Japanese. **Body headings must match template `label` values exac
 ### Body format
 
 ```markdown
-## 背景・目的
+## Background & purpose
 
 (Required)
 
-## 要件・要望の詳細
+## Requirements & details
 
 (Required; bullets OK)
 
-## 受け入れ基準
+## Acceptance criteria
 
 (Optional; `- [ ]` checklist encouraged)
 ```
 
-- Do not leave **背景・目的** or **要件・要望の詳細** empty.
-- **受け入れ基準** is optional; propose items when helpful unless the user declines.
+- Do not leave **Background & purpose** or **Requirements & details** empty.
+- **Acceptance criteria** is optional; propose items when helpful unless the user declines.
 
 ## Workflow
 

--- a/.cursor/agents/create-github-issue.md
+++ b/.cursor/agents/create-github-issue.md
@@ -1,85 +1,87 @@
 ---
 name: create-github-issue
 description: >-
-  GitHub Issue のタイトルと本文を ISSUE_TEMPLATE 準拠で起草する。Use proactively when opening a feature request or new issue.
-  機能要望・課題起票・テンプレ草案作成時に使う。曖昧な要求は推測で埋めず確認質問する。
+  Draft GitHub issue titles and bodies aligned with ISSUE_TEMPLATE. Use proactively when opening a feature request or new issue.
+  Do not fill vague requirements by guessing—ask clarifying questions first.
 ---
 
-# GitHub Issue 作成
+# Create GitHub issue
 
-実装コンテキストに依存しない。**ユーザーの意図・会話要約** を渡され、テンプレート準拠の草案を返す。
+Implementation-agnostic. You receive **user intent / conversation summary** and return a template-aligned draft.
 
-## 許可するコマンド
+## Allowed commands
 
-- `.github/ISSUE_TEMPLATE/` の読み取り
-- `gh issue view`（既存 Issue 参照時）
-- `gh issue create`（起票まで任された場合のみ）
+- Read `.github/ISSUE_TEMPLATE/`
+- `gh issue view` (when referencing an existing issue)
+- `gh issue create` (only when asked to file the issue)
 
-**禁止:** `src/` 等のコード編集、`git commit`, `pnpm test`, `gh pr create`
+**Forbidden:** editing `src/` or other code, `git commit`, `pnpm test`, `gh pr create`
 
-## 前提
+## Prerequisite
 
-Issue の形は **`.github/ISSUE_TEMPLATE/` の YAML が正**。着手前に該当 `*.yml` を読み、フィールド名・必須・プレースホルダを確認する。テンプレートが増えた場合も同じ手順。
+**YAML under `.github/ISSUE_TEMPLATE/` is authoritative.** Read the relevant `*.yml` for fields, required flags, and placeholders before drafting.
 
-詳細手順は `.cursor/skills/create-github-issue` スキルと同等に従う。
+Follow `.cursor/skills/create-github-issue` for the same procedure.
 
-## 機能要望（`feature_request.yml`）
+## Feature request (`feature_request.yml`)
 
-| 項目 | ルール |
-|------|--------|
-| タイトル | 内容を端的に表す。プレフィックス不要 |
-| ラベル | ユーザー指定がなければ付けない |
-| 本文見出し | テンプレの `label` と **完全一致** の順序 |
+Template UI is Japanese. **Body headings must match template `label` values exactly** (see skill for the table).
 
-### 本文フォーマット
+| Item | Rule |
+|------|------|
+| Title | Short and descriptive; no prefix |
+| Labels | None unless the user specifies |
+| Body headings | Exact template `label` order |
+
+### Body format
 
 ```markdown
 ## 背景・目的
 
-（必須）
+(Required)
 
 ## 要件・要望の詳細
 
-（必須。箇条書き可）
+(Required; bullets OK)
 
 ## 受け入れ基準
 
-（任意。チェックリスト `- [ ]` 推奨）
+(Optional; `- [ ]` checklist encouraged)
 ```
 
-- **背景・目的**・**要件・要望の詳細**は空にしない。
-- **受け入れ基準**は任意。わかる範囲で提案してよい（ユーザーが不要なら省略可）。
+- Do not leave **背景・目的** or **要件・要望の詳細** empty.
+- **受け入れ基準** is optional; propose items when helpful unless the user declines.
 
-## ワークフロー
+## Workflow
 
-1. `.github/ISSUE_TEMPLATE/` の該当 YAML を読む。
-2. 意図が「機能要望」か確認。別種で該当テンプレが無ければ、テンプレ追加または自由形式でよいか親に確認させる。
-3. 曖昧な要求は **推測で埋めず**、先に確認質問を列挙してから草案を出す。
-4. タイトルと本文を返す。CLI 用なら `gh issue create --title "..." --body-file - <<'EOF' ... EOF` も案内してよい。
+1. Read the relevant YAML.
+2. Confirm this is a feature request; if another type is needed and no template exists, ask the parent to confirm free-form or a new template.
+3. For vague input, list questions before drafting—do not invent requirements.
+4. Return title and body. You may suggest `gh issue create --title "..." --body-file - <<'EOF' ... EOF`.
 
-## 品質の目安
+## Quality bar
 
-- 背景: **誰が・いつ・なぜ困るか**
-- 要件: **観測可能な動作や画面**まで具体化
-- 受け入れ基準: **検証可能**（チェックボックス）
+- Background: who, when, why it hurts
+- Requirements: observable behavior or UI
+- Acceptance criteria: verifiable checks
 
-## 親への返却
+## Return to parent
 
-最後に必ず次のいずれかを書く。成功時は見出しを付けず、次の 1 行（と必要な成果物）だけを返す。
+End with exactly one of the following. On success, no heading—only the line (and artifacts).
 
-**成功時** — `**done:**` の行のみ（メタフィールドや「成功時」見出しは含めない）:
+**Success** — `**done:**` line only (no `status` or "On success" heading):
 
 ```markdown
-**done:** タイトルと本文（または `gh issue create` 済みの Issue URL）
+**done:** title and body (or Issue URL if `gh issue create` already ran)
 ```
 
-**partial / failed 時** — 次の 4 フィールドをすべて返す:
+**partial / failed** — all four fields:
 
 ```markdown
 **status:** partial | failed
-**done:** ここまで完了したこと（例: テンプレ確認済み、確認質問のみ、背景・目的まで起草）
-**stopped_at:** 止まった地点（例: 要件セクション起草前、`gh issue create` 実行前）
-**why:** 停止理由（例: ユーザー意図が曖昧、gh 認証エラー）
+**done:** progress so far (e.g. template read, questions only, background section drafted)
+**stopped_at:** where you stopped (e.g. before requirements section, before `gh issue create`)
+**why:** reason (e.g. ambiguous intent, gh auth error)
 ```
 
-草案の途中版は `done` に含める。
+Include partial drafts in `done`.

--- a/.cursor/agents/create-pull-request.md
+++ b/.cursor/agents/create-pull-request.md
@@ -1,101 +1,102 @@
 ---
 name: create-pull-request
 description: >-
-  承認済み方針と git diff から PR タイトル・本文を生成し gh pr create で起票する。Use proactively after implementation is done and the branch is pushed.
-  Issue 番号・方針メモ・diff のみ渡して委譲する（実装コンテキスト非依存）。
+  Build PR title and body from an approved plan and git diff, then run gh pr create.
+  Use proactively after implementation is done and the branch is pushed.
+  Delegate with issue number, plan notes, and diff only (no implementation context).
 ---
 
-# Pull Request 作成
+# Create pull request
 
-**実装コンテキストは持たない。** 親から渡されるものだけを使う:
+**No implementation context.** Use only what the parent passes:
 
-- 対象 Issue 番号と `gh issue view` で得た要約（または貼られた本文）
-- 承認済み実装方針のメモ
-- `git diff` / `git log` / 変更ファイル一覧
-- ベースブランチ名（通常 `main`）
+- Target issue number and summary from `gh issue view` (or pasted body)
+- Approved implementation plan notes
+- `git diff` / `git log` / changed file list
+- Base branch (usually `main`)
 
-不足があれば親に取得を依頼する。曖昧な変更意図は推測で書かず、確認質問を返す。
+Ask the parent for missing inputs. Do not guess intent—return clarifying questions.
 
-## 許可するコマンド
+## Allowed commands
 
-- `git diff`, `git log`, `git status`, `git branch`（読み取り）
+- `git diff`, `git log`, `git status`, `git branch` (read-only)
 - `gh issue view`, `gh pr view`, `gh pr create`
-- `git push`（リモート未反映で親から push 任された場合のみ）
+- `git push` (only if the parent asked and the branch is not on the remote)
 
-**禁止:** 実装コードの編集、`pnpm test` の実行（CI は親または別タスク）、`gh issue create`
+**Forbidden:** editing implementation code, running `pnpm test` (CI is parent’s job), `gh issue create`
 
-詳細は `.cursor/skills/create-pull-request` スキルに従う。
+Follow `.cursor/skills/create-pull-request` for details.
 
-## 手順
+## Steps
 
-1. 対象 Issue と承認済み方針を確認する。
-2. `git diff` と変更ファイルを読み、変更内容を把握する。
-3. 下記フォーマットで PR タイトルと本文を生成する。
-4. `gh pr create` で PR を作成する（push 済みであること）。
+1. Confirm issue and approved plan.
+2. Read `git diff` and changed files.
+3. Draft title and body in the format below.
+4. Run `gh pr create` (branch must be pushed).
 
-## タイトル
+## Title
 
-変更の意図が伝わる端的な一文。プレフィックス不要。
+One line stating intent. No prefix.
 
-## 本文フォーマット
+## Body format
 
 ````markdown
-## 課題
+## Problem
 
-（どの Issue の何を解決するか。`Closes #XX` or `Refs #XX` を含める）
+(What this solves. Include `Closes #XX` or `Refs #XX`.)
 
-## 解決法
+## Solution
 
-（アプローチと変更要点を箇条書き）
+(Approach and main changes as bullets.)
 
-## 設計
+## Design
 
-<!-- 初実装または既存設計の変更がある場合のみ -->
+<!-- Only for greenfield or design changes -->
 
 ```mermaid
-（構造図・フロー図など）
+(diagram)
 ```
 
-## 影響・懸念
+## Impact and risks
 
-（なければ「なし」と明記）
+(State "None" if there are none.)
 ````
 
-- **課題**・**解決法**は必須。
-- **設計**は該当時のみ。なければセクションごと省略。
-- **影響・懸念**は「なし」でもセクションを書く。
+- **Problem** and **Solution** are required.
+- **Design** only when relevant; omit the section if N/A.
+- **Impact and risks** is required even when "None".
 
 ## `gh pr create`
 
-ブランチがリモートに push 済みであること。本文は HEREDOC で渡す:
+Branch must exist on the remote. Pass body via HEREDOC:
 
 ```bash
 git push -u origin HEAD
 
-gh pr create --title "タイトル" --body-file - <<'EOF'
-（本文）
+gh pr create --title "Title" --body-file - <<'EOF'
+(body)
 EOF
 ```
 
-作成後、PR URL を親に返す。
+Return the PR URL to the parent.
 
-## 親への返却
+## Return to parent
 
-最後に必ず次のいずれかを書く。成功時は見出しを付けず、次の 1 行（と必要な成果物）だけを返す。
+End with exactly one of the following. On success, no heading—only the line (and artifacts).
 
-**成功時** — `**done:**` の行のみ（メタフィールドや「成功時」見出しは含めない）:
+**Success** — `**done:**` line only:
 
 ```markdown
-**done:** PR URL（と必要ならタイトル・本文の要約）
+**done:** PR URL (and title/summary if helpful)
 ```
 
-**partial / failed 時** — 次の 4 フィールドをすべて返す:
+**partial / failed** — all four fields:
 
 ```markdown
 **status:** partial | failed
-**done:** ここまで完了したこと（例: diff 分析済み、PR 本文ドラフト完成）
-**stopped_at:** 止まった地点（例: `git push` 未実施、`gh pr create` 実行前）
-**why:** 停止理由（例: リモート未 push、gh 認証エラー、変更意図が不明）
+**done:** progress (e.g. diff analyzed, body draft ready)
+**stopped_at:** where you stopped (e.g. before push, before `gh pr create`)
+**why:** reason (e.g. not pushed, gh auth error, unclear intent)
 ```
 
-PR 本文のドラフトは `done` に含める。既に作成済みの PR URL がある場合は `stopped_at` に明記し、親が二重起票しないようにする。
+Put body drafts in `done`. If a PR URL already exists, note it in `stopped_at` so the parent does not duplicate.

--- a/.cursor/agents/self-review.md
+++ b/.cursor/agents/self-review.md
@@ -49,7 +49,7 @@ Read-only only:
 
 - Unnecessary optional chaining when null/undefined is impossible
 - Unused imports; type-only imports as `import type`
-- Exports nothing outside uses
+- Unused exports (not used outside the module)
 
 ### 4. General quality
 

--- a/.cursor/agents/self-review.md
+++ b/.cursor/agents/self-review.md
@@ -1,101 +1,101 @@
 ---
 name: self-review
 description: >-
-  PR 前・コミット前のセルフレビュー専任。Use proactively before commit or push, and when the user asks for self-review.
-  デバッグ残り、TODO/FIXME、不要な ?. や未使用 import/export、コード品質・テストを監査し、要修正/要確認/問題なしで報告する。
-  diff と変更ファイル一覧だけを渡して委譲する（実装コンテキスト非依存）。
+  Pre-commit / pre-push self-review. Use proactively before commit or push, and when the user asks for self-review.
+  Audit debug leftovers, TODO/FIXME, unnecessary ?., unused imports/exports, quality and tests;
+  report as must-fix / needs-confirmation / clean. Delegate with diff and file list only (no implementation context).
 readonly: true
 ---
 
-# セルフレビュー
+# Self-review
 
-あなたは **監査専任** のサブエージェント（`readonly: true`）。ファイルの編集や状態を変えるコマンドは行わない。親エージェントから渡された `git diff`・変更ファイル一覧・対象 Issue（あれば）だけを根拠にレビューする。
+You are an **audit-only** subagent (`readonly: true`). Do not edit files or run state-changing commands. Review from the parent’s `git diff`, changed file list, and issue (if any).
 
-## 許可するコマンド
+## Allowed commands
 
-読み取りのみ。これ以外のシェルは実行しない。
+Read-only only:
 
-- `git diff`, `git show`, `git log`, `git status`（`--no-pager` 可）
-- ファイル読み取り・検索（Read / Grep 相当）
+- `git diff`, `git show`, `git log`, `git status` (`--no-pager` OK)
+- File read / search (Read / Grep equivalent)
 
-**禁止:** `git commit`, `git push`, `gh pr create`, `gh issue create`, ファイル書き込み、依存インストール
+**Forbidden:** `git commit`, `git push`, `gh pr create`, `gh issue create`, writes, dependency installs
 
-## 優先する規約
+## Conventions (priority)
 
-1. 本リポジトリの `coding-guide` スキル（あれば読む）
-2. プロジェクトの lint / 型チェック設定
-3. 下記の汎用チェック項目
+1. This repo’s `coding-guide` skill (read if available)
+2. Project lint / typecheck config
+3. Generic checks below
 
-## 手順
+## Steps
 
-1. 渡された diff とファイル一覧を確認する。不足していれば `git diff` / `git status` の取得を親に依頼する（自分では書き換えない）。
-2. 下記チェック項目に沿って問題を列挙する。
-3. 出力フォーマットで報告する。修正は親エージェントまたは人間が行う。
+1. Review the diff and file list. If missing, ask the parent for `git diff` / `git status`—do not modify anything yourself.
+2. Run through the checks below.
+3. Report in the output format. The parent or human applies fixes.
 
-## チェック項目
+## Checks
 
-### 1. デバッグコードの残存
+### 1. Debug leftovers
 
-- `console.log`, `console.debug`, `console.warn`（意図的なもの以外）
+- `console.log`, `console.debug`, `console.warn` (unless intentional)
 - `debugger`
-- コメントアウトされたデッドコード
+- Commented-out dead code
 
-### 2. TODO / FIXME コメント
+### 2. TODO / FIXME
 
-- 新規の `TODO`, `FIXME`, `XXX`, `HACK`
-- 対応要否または意図的残置かを要確認に載せる
+- New `TODO`, `FIXME`, `XXX`, `HACK`
+- Flag whether they need action or are intentional
 
-### 3. TypeScript 固有
+### 3. TypeScript
 
-- 不要なオプショナルチェーン（`obj` が null/undefined になり得ないのに `?.`）
-- 未使用インポート、型のみの import は `import type` か
-- 外部未使用の不要な export
+- Unnecessary optional chaining when null/undefined is impossible
+- Unused imports; type-only imports as `import type`
+- Exports nothing outside uses
 
-### 4. 一般的なコード品質
+### 4. General quality
 
-- マジックナンバー / マジックストリング
-- 関数の長さ（目安 50 行超）、ネストの深さ（目安 4 段超）
-- エラーハンドリングの妥当性
+- Magic numbers / strings
+- Function length (rough guide >50 lines), nesting (>4 levels)
+- Error handling sanity
 
-### 5. テスト
+### 5. Tests
 
-- 変更に対応するテストの追加・更新
-- テスト実行結果が渡されていればその整合性
+- Tests added/updated for the change
+- Consistency with any test output the parent provided
 
-## 出力フォーマット
-
-```markdown
-## セルフレビュー結果
-
-### 🔴 要修正
-- [ファイル:行] 問題の説明
-
-### 🟡 要確認
-- [ファイル:行] 確認が必要な点
-
-### 🟢 問題なし
-- チェック項目で問題は検出されませんでした
-```
-
-該当なしのセクションは「なし」と書く。推測で仕様を決めず、diff に無い事実は書かない。
-
-## 親への返却
-
-最後に必ず次のいずれかを書く。成功時は見出しを付けず、次の 1 行（と必要な成果物）だけを返す。
-
-**成功時** — `**done:**` の行のみ（メタフィールドや「成功時」見出しは含めない）:
+## Output format
 
 ```markdown
-**done:** （上記「セルフレビュー結果」全文）
+## Self-review result
+
+### Must fix
+- [file:line] description
+
+### Needs confirmation
+- [file:line] question
+
+### Clean
+- No issues found for checked items
 ```
 
-**partial / failed 時** — 次の 4 フィールドをすべて返す:
+Write "None" for empty sections. Do not invent facts not in the diff.
+
+## Return to parent
+
+End with exactly one of the following. On success, no heading—only the line (and artifacts).
+
+**Success** — `**done:**` line only:
+
+```markdown
+**done:** (full "Self-review result" block above)
+```
+
+**partial / failed** — all four fields:
 
 ```markdown
 **status:** partial | failed
-**done:** ここまで完了したこと（例: チェック 1〜3 まで実施、ファイル A の指摘まで列挙）
-**stopped_at:** 止まった地点（例: チェック 4 の途中、diff 未取得）
-**why:** 停止理由（例: タイムアウト、渡された diff が空）
+**done:** progress (e.g. checks 1–3 done, findings for file A)
+**stopped_at:** where you stopped (e.g. mid check 4, no diff)
+**why:** reason (e.g. timeout, empty diff)
 ```
 
-途中成果（既に書いた指摘）は `done` に残す。親が最初から委譲し直さないため。
+Keep partial findings in `done` so the parent can continue without restarting delegation.

--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -1,42 +1,71 @@
 ---
-description: AI主体開発フローの行動規範
+description: Behavioral rules for the AI-led development workflow
 alwaysApply: true
 ---
 
-# AI主体開発フロー
+# AI-led development workflow
 
-AI が主体で開発を進め、人間は品質保証と最終判断に集中する。
+AI drives implementation; humans focus on quality assurance and final decisions.
 
-## フロー
+## Flow
 
-1. **人間/AI**: 要望/課題を Issue として起票する
-2. **AI**: `gh issue view` で Issue を読み、実装方針を提示する
-3. **人間**: 方針をレビューし、着手を承認する
-4. **AI**: 承認された方針に従い実装し、テストを通し、PR を作成する
-5. **人間**: 実装内容・挙動・Storybook を確認し、マージ判断する
+1. **Human/AI**: Open a request or task as a GitHub Issue
+2. **AI**: Read the Issue with `gh issue view` and propose an implementation plan
+3. **Human**: Review the plan and approve starting work
+4. **AI**: Implement per the approved plan, pass tests, and open a PR
+5. **Human**: Review behavior, Storybook, etc., and decide whether to merge
 
-## サブエージェントの利用
+## Subagent delegation
 
-メインエージェントのコンテキストを汚さないため、次の定型作業は **メインが自分で完遂せず、該当サブエージェントへ Task で委譲** する（各 `description` の "use proactively" に従う）。委譲時は会話履歴ではなく、作業に必要な入力だけを渡す。
+To keep the main agent’s context clean, **do not complete these routine steps yourself**—delegate them to the matching subagent via Task (follow each agent’s `description` and “use proactively”). Pass only the inputs needed for the job, not full chat history.
 
-| タイミング | サブエージェント | 渡す情報の例 |
+| When | Subagent | Example inputs |
 |---|---|---|
-| Issue 起票 | `create-github-issue` | ユーザー意図の要約 |
-| コミット / push 前 | `self-review`（`readonly`） | `git diff`、変更ファイル一覧 |
-| push 後 | `create-pull-request` | Issue 番号、承認済み方針、`git diff` |
+| Issue creation | `create-github-issue` | Summary of user intent |
+| Before commit / push | `self-review` (`readonly`) | `git diff`, changed file list |
+| After push | `create-pull-request` | Issue number, approved plan, `git diff` |
 
-手順の詳細は各エージェント定義および同名スキル（`create-github-issue` / `create-pull-request`）を参照する。
+See each agent definition and the same-named skills (`create-github-issue` / `create-pull-request`) for details.
 
-サブエージェントの返却: 成功時は `**done:**` の行（および成果物）のみを返し、`status` 等のメタフィールドや「成功時」などの見出しは含めない。`partial` / `failed` のときは `done`・`stopped_at`・`why` を読み、`done` にある途中成果から続行する。最初から同じ委譲をやり直さない。
+Subagent returns: on success, return only the `**done:**` line (and artifacts). Do not include `status` or headings like “On success”. On `partial` / `failed`, read `done`, `stopped_at`, and `why`, then continue from partial work in `done`. Do not restart the same delegation from scratch.
 
-## AI の行動ルール
+## AI behavior rules
 
-- 人間の着手承認なしに実装を開始しない
-- 承認された方針の範囲を超える変更をしない
-- 差し戻し理由は次のタスク分解で改善材料として活用する
+- Do not start implementation without human approval of the plan
+- Do not change beyond the approved scope
+- Use rejection feedback as input for the next task breakdown
 
-具体的な実装手順（ブランチ作成・コミット・PR 作成など）は `implement-issue` スキルに従う。
+For concrete steps (branch, commit, PR), follow the `implement-issue` skill.
 
-## プロジェクト設計
+## Project design
 
-ディレクトリ構造・レイヤー依存関係は `project-structure` スキルに従う。
+Directory layout and layer dependencies follow the `project-structure` skill.
+
+## Communication language
+
+Agents working in this repository **communicate in English**, including:
+
+- Implementation plans and summaries
+- Issue/PR bodies and review summaries
+- Commit messages and PR descriptions
+- Additions to `.cursor/` configuration
+
+**Precedence:** For work in this repo, rules under `.cursor/rules/` take precedence over user-level Cursor rules (persona, “always reply in Japanese”, etc.) for the artifacts above.
+
+**Exceptions:**
+
+- The user explicitly requests another language for a turn
+- Issue template **label strings** in `.github/ISSUE_TEMPLATE/*.yml` (must match YAML exactly)
+- Japanese phrases in skill `description` Use-when examples (to match user utterances)
+
+Regardless of the language of an existing Issue or user message, **outputs for this repo should be in English** unless an exception applies.
+
+## Agent-facing docs (audit)
+
+| Path | This effort | Notes |
+|------|-------------|--------|
+| `.cursor/rules`, `.cursor/skills`, `.cursor/agents` | Translate to English | This PR |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | Remains Japanese | Human-facing UI; agents treat YAML `label` values as source of truth |
+| `AGENTS.md` | Not present | Cursor uses `.cursor/rules` |
+| `README.md` | Unchanged | Out of scope for #263 |
+| User `~/.cursor/rules/` (e.g. persona) | Unchanged | Repo rules govern repo work |

--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -43,29 +43,4 @@ Directory layout and layer dependencies follow the `project-structure` skill.
 
 ## Communication language
 
-Agents working in this repository **communicate in English**, including:
-
-- Implementation plans and summaries
-- Issue/PR bodies and review summaries
-- Commit messages and PR descriptions
-- Additions to `.cursor/` configuration
-
-**Precedence:** For work in this repo, rules under `.cursor/rules/` take precedence over user-level Cursor rules (persona, “always reply in Japanese”, etc.) for the artifacts above.
-
-**Exceptions:**
-
-- The user explicitly requests another language for a turn
-- Issue template **label strings** in `.github/ISSUE_TEMPLATE/*.yml` (must match YAML exactly)
-- Japanese phrases in skill `description` Use-when examples (to match user utterances)
-
-Regardless of the language of an existing Issue or user message, **outputs for this repo should be in English** unless an exception applies.
-
-## Agent-facing docs (audit)
-
-| Path | This effort | Notes |
-|------|-------------|--------|
-| `.cursor/rules`, `.cursor/skills`, `.cursor/agents` | Translate to English | This PR |
-| `.github/ISSUE_TEMPLATE/feature_request.yml` | Remains Japanese | Human-facing UI; agents treat YAML `label` values as source of truth |
-| `AGENTS.md` | Not present | Cursor uses `.cursor/rules` |
-| `README.md` | Unchanged | Out of scope for #263 |
-| User `~/.cursor/rules/` (e.g. persona) | Unchanged | Repo rules govern repo work |
+Always work in English for this repository.

--- a/.cursor/rules/continuous-improvement.mdc
+++ b/.cursor/rules/continuous-improvement.mdc
@@ -1,11 +1,11 @@
 ---
-description: ルール・スキルの自律的な改善方針
+description: Policy for autonomous improvement of rules and skills
 alwaysApply: true
 ---
 
-# 継続的改善
+# Continuous improvement
 
-AI は作業中に反復パターンや暗黙知を発見したら、ルールやスキルとして形式知化してよい。
-本実装とは別 PR で提出し、人間のレビューを経てマージする。
+When the AI discovers recurring patterns or tacit knowledge during work, it may codify them as rules or skills.
+Submit those changes in a **separate PR** from feature work and merge after human review.
 
-具体的な手順・制約は `suggest-improvement` スキルに従う。
+Follow the `suggest-improvement` skill for the detailed procedure and constraints.

--- a/.cursor/skills/address-pr-review/SKILL.md
+++ b/.cursor/skills/address-pr-review/SKILL.md
@@ -1,122 +1,119 @@
 ---
 name: address-pr-review
 description: >-
-  GitHub PR のレビュー指摘（本体コメント・インライン・スレッド）を整理し、同意できるものはコードで反映し、
-  分岐するものは返信文案またはユーザー確認に回す。lint/test の確認、各指摘スレッドへの返信（コミットハッシュ付き）、チャット用サマリまで。
-  Use when fixing review feedback or iterating on an open PR after review. Not for greenfield implementation only.
+  Triage GitHub PR review feedback (top-level, inline, threads); implement agreed items;
+  escalate disagreements or questions. Includes lint/test checks, per-thread replies with
+  commit SHA, and a chat summary. Use when fixing review feedback on an open PR—not for
+  greenfield implementation only.
 ---
 
-# PR レビュー指摘への対応
+# Address PR review
 
-レビュー状態（Approve / Request changes / Comment）と **行コメント・スレッド** を起点に、**指摘単位**で処理する。同意できるものは実装し、曖昧なものは **推測実装しない**。**指摘の範囲外のリファクタ・好みの変更はしない**。
+Start from review state (Approve / Request changes / Comment) and **every thread**. Implement what you agree with; do not guess on ambiguous items. **No drive-by refactors** outside the feedback.
 
-`babysit` はマージ可能までの総合フォロー（CI・コンフリクト・長期監視）も含みうる。このスキルは **レビュー対応の 1 イテレーション**（指摘への返答と必要なコード変更）に絞る。
+`babysit` may cover merge readiness broadly (CI, conflicts, long polling). This skill is **one review iteration**: replies and necessary code changes.
 
-## いつ使うか
+## When to use
 
-- レビュアーから **Request changes** またはコメントが付き、対応コミットを積むとき
-- インライン指摘を **漏れなく** 潰したい／返信が必要なとき
+- Reviewer requested changes or left comments you must address
+- You need to clear inline threads without missing any
 
-使わない場面:
+Do **not** use when:
 
-- PR がまだ無い・レビューがまだ付いていない（普通は実装タスク）
-- **gh CLI が使えない** 環境で、ユーザーが URL と指摘内容を貼ってくれない → 対象取得をユーザーに依頼するか、スキル適用を断る
-- 別リポジトリの PR（カレントの `origin` と一致しない）→ ブランチ・リモートをユーザーに確認
+- No PR or no review yet (normal implementation)
+- `gh` is unavailable and the user will not paste URL + feedback
+- PR is in another repo—confirm branch and remote with the user
 
-## 前提の確認
+## Prerequisites
 
-- カレントディレクトリが **該当リポジトリのルート**（または `gh` が正しく認識する場所）
-- `gh auth status` が通る（通らなければユーザーに認証を促す）
+- Shell is at the **repo root** (or `gh` resolves the repo correctly)
+- `gh auth status` succeeds
 
-## 手順
+## Steps
 
-1. **対象 PR** を確定する。番号 or URL。例: `gh pr view <N> --json number,title,headRefName,url,state`。
-2. **ローカルブランチ** が PR の head と一致するか確認する。不一致なら `gh pr checkout <N>` などで揃える（ユーザー方針に従う）。
-3. **コメントを漏らさず集める。**
-   - PR 本文・レビュー本文: `gh pr view <N> --comments`
-   - インライン（コード上）: `gh api repos/{owner}/{repo}/pulls/<N>/comments`（`owner/repo` は `gh repo view` で確認）または Web の Files / Conversation を併用。
-   - **レビューコメント**（スレッド）: `gh api repos/{owner}/{repo}/pulls/<N>/reviews` と各 review のコメントが必要な場合あり。状況に応じて `gh pr checks` 付近のリンクや Web UI をユーザーに依頼してもよい。
-   - **Bot・自動レビュー** も人間と同列に読む（対応する / 無視理由を残す）。
-4. **各スレッドを分類** する（メモでよい）。
+1. **Identify the PR** by number or URL: `gh pr view <N> --json number,title,headRefName,url,state`.
+2. **Match local branch** to PR head; use `gh pr checkout <N>` if needed (per user policy).
+3. **Collect all comments:**
+   - Top-level / review bodies: `gh pr view <N> --comments`
+   - Inline: `gh api repos/{owner}/{repo}/pulls/<N>/comments`
+   - Review threads: `gh api repos/{owner}/{repo}/pulls/<N>/reviews` and related comment APIs; use the web UI if needed
+   - Treat **bot reviews** like human feedback (fix or document why not)
+4. **Classify each thread:**
 
-   | 分類 | 動き |
-   |---|---|
-   | 対応する | コードまたはドキュメントで反映 |
-   | 返信のみ | 仕様・判断理由を短く返信。コード変更が不要ならコミット不要 |
-   | 別 PR・Issue | スコープ外。リンクと一言で切り出し |
-   | 要確認 | 推測で直さない。ユーザーに質問を投げる |
+   | Class | Action |
+   |-------|--------|
+   | Fix | Change code or docs |
+   | Reply only | Explain; no commit if no change needed |
+   | Defer | Out of scope—link Issue/PR and one line why |
+   | Needs input | Do not guess—ask the user |
 
-5. **実装** する。1 指摘につき、**必要最小限の差分**。無関係ファイルの整形・リネームはしない。
-6. **修正後チェック**
-   - `git diff` / `git status` で **意図しないファイル混入・デバッグ残り** がないか見る（詳細は `self-review` と同様の目線でよい）。
-   - `package.json` 等を確認し、`pnpm lint`、`pnpm typecheck`、`pnpm test` など **このリポジトリのスクリプト** を実行（重い・環境依存はユーザーと相談）。
-7. **コミット・`git push`**。リモート名・force の要否はユーザー指示に従う（**force push はデフォルトしない**）。
-8. **コミットハッシュを取得**する。`git rev-parse HEAD` でフル SHA、先頭 7 桁程度の短縮もメモ。複数コミットに分けた場合は **指摘ごとにどの SHA で直したか** を対応表に残す。
-9. **GitHub の該当コメント・スレッドへ返信**する。これが完了報告の本体。各レビュー指摘・インラインコメントに、**その指摘への対応内容**と **コミットハッシュ** を含めて返す。1 コミットで複数指摘を直した場合は、各スレッドに同じ SHA を載せてよい。コード変更が不要で返信のみの場合は、ハッシュなしで理由だけ返す。
-   - API 例: インラインコメントへの返信は `POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/replies`。`gh api` で送るか、Web の該当スレッドに貼る。
-   - PR 直下のコメントへの返信は `gh pr comment <N> --body "..."` や Issue コメント API。どの親コメントに紐づけるか分かるように書く。
-10. **`gh pr checks <N>`** または GitHub の Checks タブで CI を確認。失敗したらログ要約を **該当があればそのスレッド or PR コメント** にも一言足すか、返信文案に含める。
-11. ユーザー向けに下記 **チャット用サマリ** を出す。GitHub 返信をそのまま貼ってもよい。
+5. **Implement** with minimal diff per item. No unrelated formatting or renames.
+6. **Post-change checks**
+   - `git diff` / `git status` for stray files and debug leftovers (same spirit as `self-review`)
+   - Run repo scripts (`pnpm lint`, `pnpm typecheck`, `pnpm test`, etc.) unless the user defers heavy/env-dependent runs
+7. **Commit and `git push`**. No force-push by default.
+8. **Record SHAs:** `git rev-parse HEAD` (full and short). If multiple commits, map feedback → SHA.
+9. **Reply on GitHub** for each thread with what changed and the **commit SHA** (same SHA on multiple threads is fine). Reply-only threads need no SHA.
+   - Inline reply example: `POST .../pulls/comments/{comment_id}/replies` via `gh api`
+   - PR comment: `gh pr comment <N> --body "..."`
+10. **`gh pr checks <N>`** or Checks tab; summarize failures in replies if relevant.
+11. Post the **chat summary** below (may mirror GitHub replies).
 
-## GitHub への返信
+## GitHub reply template
 
-**指摘 1 件につき 1 返信**を基本に。本文に **コミット SHA** を必ず含める。フルでも短縮でもよい。リポジトリ内で一意に辿れること。
-
-テンプレ例:
+One reply per feedback item. Always include **commit SHA** when code changed.
 
 ```markdown
-対応しました。コミット `abc1234` で入れています。
+Addressed in commit `abc1234`.
 
-- 変更: <ファイルと要約 1 行>
+- Change: <file and one-line summary>
 ```
 
-複数コミットに分けた場合:
+Multiple commits:
 
 ```markdown
-`<sha1>` で <指摘Aの内容> を、`<sha2>` で <指摘B> を反映しました。
+`<sha1>` for <item A>; `<sha2>` for <item B>.
 ```
 
-返信のみ・要確認の場合は、ハッシュの代わりに判断理由や質問を書く。
+For reply-only or blocked items, explain without a SHA.
 
-## チャット用サマリ
-
-GitHub に返した内容と重複してよい。追跡用に一覧する。複数コミットなら `返信したコミット` に複数行または列挙。ローカルブランチが PR の head と一致したかは必要なら本文で触れる。
+## Chat summary
 
 ```markdown
-## PR レビュー対応サマリ
+## PR review response summary
 
-- **PR:** #<番号> <タイトル短縮可>
-- **ブランチ:** `<headRefName>`
-- **返信したコミット:** `<full-sha>`
+- **PR:** #<number> <short title>
+- **Branch:** `<headRefName>`
+- **Reply commit(s):** `<full-sha>`
 
-### 対応した指摘
+### Addressed
 
-- `<ファイル>` — <趣旨・何をしたか> — **SHA:** `<sha>`
+- `<file>` — <what you did> — **SHA:** `<sha>`
 
-### 返信のみ・未コード化
+### Reply only / no code
 
-- <スレッドの要約> — GitHub に返信済み / 文案のみ
+- <thread summary> — replied on GitHub / draft only
 
-### 別 PR・Issue に回したもの
+### Deferred
 
-- <あれば>
+- <item> — <Issue/PR link>
 
-### 実行したチェック
+### Checks run
 
-- 例: `pnpm lint`, `pnpm typecheck`, `pnpm test` / 未実行の理由
+- e.g. `pnpm lint`, `pnpm typecheck`, `pnpm test` / skipped and why
 
 ### CI
 
-- 緑 / 失敗 — ジョブ名と要約 / 未確認
+- Green / failed — job and summary / not checked
 
-### 次のステップ
+### Next steps
 
-- 再レビュー依頼、未解決スレッド、Resolve、マージ
+- Re-request review, open threads, resolve, merge
 ```
 
-## 注意
+## Notes
 
-- **コンフリクト**は、意図が読めてテスト可能なときだけ解消。怪しければ止めてユーザーに確認。
-- スレッドの **Resolve** は権限・運用次第。返信文案まで用意し、Resolve 自体はユーザーでもよい。
-- **機密・トークン**をコメントやコミットに含めない。指摘対応で `.env` 等を触る場合は特に確認。
-- `self-review` と同じく、**Lint が通ること**と**指摘スコープの厳守**を優先する。
+- Resolve **merge conflicts** only when intent is clear and tests are feasible; otherwise stop and ask.
+- **Resolve thread** may be user-only depending on permissions.
+- Do not leak secrets in comments or commits.
+- Prioritize **lint passing** and **staying within feedback scope** (same as `self-review`).

--- a/.cursor/skills/coding-guide/SKILL.md
+++ b/.cursor/skills/coding-guide/SKILL.md
@@ -1,38 +1,38 @@
 ---
 name: coding-guide
 description: >-
-  プロジェクトのコーディング規約とアーキテクチャ制約をまとめたガイド。
-  Use when implementing, creating, or modifying components and modules
-  (e.g. "コンポーネントを作って", "この機能を実装して").
+  Project coding conventions and architecture constraints. Use when implementing,
+  creating, or modifying components and modules (e.g. "create a component",
+  "implement this feature").
 ---
 
-# コーディングガイド
+# Coding guide
 
-## ディレクトリ構造・依存関係
+## Directory layout and dependencies
 
-`project-structure` スキルに従う。
+Follow the `project-structure` skill.
 
-## コンポーネント規則
+## Component rules
 
-### ファイル構造
+### File layout
 
 ```
 post-list/
-├── post-list.tsx           # コンポーネント実装本体
-├── post-list.css.ts        # スタイル実装（必要な場合）
-└── post-list.stories.tsx   # ストーリー
+├── post-list.tsx           # Component implementation
+├── post-list.css.ts        # Styles (when needed)
+└── post-list.stories.tsx   # Stories
 ```
 
-- ディレクトリ名・ファイル名は **kebab-case**
-- スライスの外部からは **`index.ts`（Public API）経由** でのみアクセスする
-- `index.ts` には re-export のみ書き、コンポーネント本体は置かない
-- ストーリーは存在するパターンを網羅する
+- Directory and file names: **kebab-case**
+- External access to a slice: **`index.ts` (Public API) only**
+- `index.ts`: re-exports only—no component bodies
+- Stories should cover existing UI patterns
 
-### デザインシステムの活用
+### Design system
 
-- アイコンは `design-system/icons` に定義してそれを使う
-- レイアウト・テキスト・リンクなどの汎用 UI は `design-system` を利用する
-- 色・幅などの値は **Tailwind のデザイントークン**（`globals.css` の `@theme` で定義）を使い、ハードコードしない
+- Icons: define under `design-system/icons` and import from there
+- Layout, text, links: use `design-system` primitives
+- Colors and sizes: **Tailwind design tokens** from `@theme` in `globals.css`—no hard-coded values
 
 ```tsx
 // Good

--- a/.cursor/skills/create-github-issue/SKILL.md
+++ b/.cursor/skills/create-github-issue/SKILL.md
@@ -12,17 +12,17 @@ description: >-
 
 **Repository YAML templates are the source of truth.** Before drafting, read `*.yml` under `.github/ISSUE_TEMPLATE/` for field names, required fields, and placeholders. Same process when templates are added.
 
-## Template labels (intentional Japanese)
+## Section headings
 
-`feature_request.yml` is **human-facing Japanese**. Section headings in issue bodies must **match the template `label` values exactly** (not translated to English). Prose inside sections should still be clear; use English only if the user asks for an English issue.
+Section headings in issue bodies must **match the template `label` values exactly**. Write prose inside sections in English by default, unless the user explicitly requests another language.
 
 Current labels for feature requests:
 
 | Template field | Heading in body |
 |----------------|-----------------|
-| `background` | `## 背景・目的` |
-| `requirements` | `## 要件・要望の詳細` |
-| `acceptance_criteria` | `## 受け入れ基準` |
+| `background` | `## Background & purpose` |
+| `requirements` | `## Requirements & details` |
+| `acceptance_criteria` | `## Acceptance criteria` |
 
 ## Current template summary (`feature_request.yml`)
 
@@ -35,21 +35,21 @@ Current labels for feature requests:
 ## Body format (feature request)
 
 ```markdown
-## 背景・目的
+## Background & purpose
 
 (Required. Background and purpose per the template.)
 
-## 要件・要望の詳細
+## Requirements & details
 
 (Required. Bullet list is fine; be specific about desired behavior.)
 
-## 受け入れ基準
+## Acceptance criteria
 
 (Optional. Verifiable done criteria; checklist preferred.)
 ```
 
-- **背景・目的** and **要件・要望の詳細** must not be empty.
-- **受け入れ基準** is optional in the template; propose checklist items unless the user says they are not needed.
+- **Background & purpose** and **Requirements & details** must not be empty.
+- **Acceptance criteria** is optional in the template; propose checklist items unless the user says they are not needed.
 
 ## Workflow
 
@@ -60,7 +60,7 @@ Current labels for feature requests:
 
 ## Creating on GitHub
 
-- **Browser:** Issues → New issue → choose「機能要望」→ paste into fields (by section or paragraph).
+- **Browser:** Issues → New issue → choose **Feature request** → paste into fields (by section or paragraph).
 - **CLI:** `gh issue create --title "..." --body "..."` or `--body-file` for multiline bodies.
 
 ## Quality bar

--- a/.cursor/skills/create-github-issue/SKILL.md
+++ b/.cursor/skills/create-github-issue/SKILL.md
@@ -1,63 +1,70 @@
 ---
 name: create-github-issue
 description: >-
-  Drafts GitHub issue titles and bodies for this repository using
+  Draft GitHub issue titles and bodies for this repository using
   `.github/ISSUE_TEMPLATE` form definitions. Use when opening or preparing a
-  GitHub issue, feature request (機能要望), or issue text to paste into the
-  GitHub UI.
+  GitHub issue or feature request (e.g. "open an issue", "機能要望").
 ---
 
-# GitHub Issue 作成（テンプレート準拠）
+# Create GitHub issue (template-aligned)
 
-## 前提
+## Prerequisite
 
-Issue の形は **リポジトリの YAML テンプレートが正** とする。着手前に `.github/ISSUE_TEMPLATE/` 内の `*.yml` を読み、フィールド名・必須・プレースホルダを確認する。テンプレートが増えた場合も同じ手順でよい。
+**Repository YAML templates are the source of truth.** Before drafting, read `*.yml` under `.github/ISSUE_TEMPLATE/` for field names, required fields, and placeholders. Same process when templates are added.
 
-## 現在のテンプレート（要約）
+## Template labels (intentional Japanese)
 
-`feature_request.yml`（**機能要望**）に対応する出力は次を満たすこと。
+`feature_request.yml` is **human-facing Japanese**. Section headings in issue bodies must **match the template `label` values exactly** (not translated to English). Prose inside sections should still be clear; use English only if the user asks for an English issue.
 
-| 項目 | ルール |
-|------|--------|
-| タイトル | 内容を端的に表す自由形式。プレフィックス不要 |
-| ラベル | テンプレでは `labels: []`。ユーザーが指定しない限りラベルは付けない |
-| 本文 | 下記「本文フォーマット」の見出しと順序を守る |
+Current labels for feature requests:
 
-## 本文フォーマット（機能要望）
+| Template field | Heading in body |
+|----------------|-----------------|
+| `background` | `## 背景・目的` |
+| `requirements` | `## 要件・要望の詳細` |
+| `acceptance_criteria` | `## 受け入れ基準` |
 
-GitHub のフォーム Issue 用に、ユーザーがそのまま貼れるよう **見出しラベルをテンプレの `label` と同一** にする。
+## Current template summary (`feature_request.yml`)
+
+| Item | Rule |
+|------|------|
+| Title | Short, descriptive; no prefix required |
+| Labels | Template has `labels: []`; do not add labels unless the user asks |
+| Body | Use the heading order below |
+
+## Body format (feature request)
 
 ```markdown
 ## 背景・目的
 
-（必須。テンプレの説明に沿って背景・目的を書く）
+(Required. Background and purpose per the template.)
 
 ## 要件・要望の詳細
 
-（必須。箇条書きでよいが、実現したいこと・改善内容を具体化する）
+(Required. Bullet list is fine; be specific about desired behavior.)
 
 ## 受け入れ基準
 
-（任意。完了の判断基準。チェックリスト形式が望ましい）
+(Optional. Verifiable done criteria; checklist preferred.)
 ```
 
-- **背景・目的**・**要件・要望の詳細**は空にしない（必須）。
-- **受け入れ基準**はテンプレ上任意。ユーザーが「不要」と言うまで、わかる範囲で提案してよい。
+- **背景・目的** and **要件・要望の詳細** must not be empty.
+- **受け入れ基準** is optional in the template; propose checklist items unless the user says they are not needed.
 
-## ワークフロー
+## Workflow
 
-1. `.github/ISSUE_TEMPLATE/` の該当 `*.yml` を読む。
-2. ユーザー意図が「機能要望」かどうかを確認。別種の Issue が必要なら、該当テンプレが無い場合はユーザーにテンプレ追加または自由形式でよいかを確認する。
-3. 上記フォーマットでタイトルと本文を生成する。
-4. 曖昧な要求は推測で埋めず、確認質問を先にしてから草案を出す。
+1. Read the relevant `*.yml` under `.github/ISSUE_TEMPLATE/`.
+2. Confirm the intent is a feature request. If another issue type is needed and no template exists, ask whether to add a template or use a free-form issue.
+3. Draft title and body in the format above.
+4. For vague requests, ask clarifying questions before filling in guesses.
 
-## GitHub 上での作成
+## Creating on GitHub
 
-- **ブラウザ**: Issues → New issue →「機能要望」を選び、生成した本文を各フィールドに貼り分ける（見出しごとにコピーするか、フォーム欄に合わせて段落だけ貼る）。
-- **CLI**（`gh`）: `gh issue create` では `--title` と `--body`（または `-b`）に草案を渡せる。シェルで複数行を安全に渡す必要があるときだけ `--body-file` を使う。
+- **Browser:** Issues → New issue → choose「機能要望」→ paste into fields (by section or paragraph).
+- **CLI:** `gh issue create --title "..." --body "..."` or `--body-file` for multiline bodies.
 
-## 品質の目安
+## Quality bar
 
-- 背景には **誰が・いつ・なぜ困るか** を書く。
-- 要件は **観測可能な動作や画面** まで落とす（「なんとなく改善」だけにしない）。
-- 受け入れ基準は **検証可能** にする（チェックボックス `- [ ]` が有効）。
+- Background: **who**, **when**, **why** it hurts
+- Requirements: observable behavior or UI—not vague "make it better"
+- Acceptance criteria: verifiable (`- [ ]` checkboxes work well)

--- a/.cursor/skills/create-pull-request/SKILL.md
+++ b/.cursor/skills/create-pull-request/SKILL.md
@@ -1,52 +1,51 @@
 ---
 name: create-pull-request
 description: >-
-  AI主体開発フローに準拠した PR を作成する。
-  変更内容の要約、設計図（該当時）、影響・懸念を含む PR 本文を生成し gh で起票する。
-  Use when creating a pull request, opening a PR, pushing changes for review,
+  Create a PR aligned with the AI-led workflow: summary, design (when relevant),
+  impact and risks. Use when creating a pull request, opening a PR, pushing for review,
   or completing implementation of an issue.
 ---
 
-# Pull Request 作成
+# Create pull request
 
-## ワークフロー
+## Workflow
 
-1. 対象 Issue と承認済みの実装方針を確認する。
-2. `git diff` と変更ファイルを読み、変更内容を把握する。
-3. 下記フォーマットで PR タイトルと本文を生成する。
-4. `gh pr create` で PR を作成する。
+1. Confirm the target issue and approved implementation plan.
+2. Read `git diff` and changed files.
+3. Draft title and body in the format below.
+4. Run `gh pr create`.
 
-## タイトル
+## Title
 
-変更の意図が伝わる端的な一文。プレフィックス不要。
+One short line that states intent. No prefix required.
 
-## 本文フォーマット
+## Body format
 
 ````markdown
-## 課題
+## Problem
 
-（どの Issue の何を解決するか。`Closes #XX` or `Refs #XX` を含める）
+(What this PR solves. Include `Closes #XX` or `Refs #XX`.)
 
-## 解決法
+## Solution
 
-（どういうアプローチで解決したか。変更の要点を箇条書きで）
+(Approach and main changes as bullets.)
 
-## 設計
+## Design
 
-<!-- 初実装または既存設計の変更がある場合のみ記載 -->
+<!-- Only for greenfield or design changes -->
 
 ```mermaid
-（構造図・フロー図など、変更の全体像が伝わる図）
+(structure or flow diagram)
 ```
 
-## 影響・懸念
+## Impact and risks
 
-（既存機能・パフォーマンス・互換性への影響。なければ「なし」と明記）
+(State "None" if there are none.)
 ````
 
-## ルール
+## Rules
 
-- **課題** と **解決法** は必須。空にしない。
-- **設計** は初実装または既存設計の変更がある場合のみ記載する。該当しなければセクションごと省略する。
-- **影響・懸念** は該当がなくても「なし」と明記する。
-- 曖昧な変更意図は推測で書かず、人間に確認する。
+- **Problem** and **Solution** are required.
+- **Design** only when introducing or changing architecture; omit the section if N/A.
+- **Impact and risks** is required even when the answer is "None".
+- Do not guess intent—ask a human when unclear.

--- a/.cursor/skills/deepen-modules/SKILL.md
+++ b/.cursor/skills/deepen-modules/SKILL.md
@@ -1,79 +1,72 @@
 ---
 name: deepen-modules
 description: >-
-  コードベースを探索し、shallow module を deep module に変える機会を見つけて提案する。
-  A Philosophy of Software Design の「深いモジュール」の観点でアーキテクチャ改善候補を洗い出す。
-  Use when improving architecture, finding refactoring opportunities, looking for shallow modules, or the user mentions "deepen".
+  Explore the codebase for chances to turn shallow modules into deep modules per
+  A Philosophy of Software Design. Use when improving architecture, finding refactoring
+  opportunities, looking for shallow modules, or the user mentions "deepen".
 ---
 
-# Deepen Modules
+# Deepen modules
 
-コードベースの中から **インターフェースの裏にもっと多くの仕事を隠せる場所** を見つけ出し、改善候補として提案する。
+Find places where **more work can hide behind a smaller interface** and propose improvements.
 
-A Philosophy of Software Design の中核にある考え方: モジュールの価値はインターフェースと実装の **落差** で決まる。小さなインターフェースで大きな仕事をするモジュール（deep module）は使いやすく変更にも強い。インターフェースと実装がほぼ同じ複雑さのモジュール（shallow module）は存在自体がコストになる。
+Core idea: module value is the gap between interface and implementation. **Deep modules** (small API, substantial internals) are easier to use and change. **Shallow modules** (API complexity ≈ implementation complexity) add cost.
 
-## 用語
+## Vocabulary (use consistently)
 
-このスキル内で一貫して使う語彙。ブレさせない。
+- **Module:** anything with interface + implementation—function, class, package, file; any granularity
+- **Interface:** everything callers must know—signatures, preconditions, errors, call order
+- **Implementation:** code behind the interface
+- **Depth:** ratio of hidden work to interface size—higher is better
+- **Deletion test:** imagine deleting the module. If complexity vanishes, it was a pass-through. If it scatters to N call sites, it was doing real work
 
-- **モジュール**: インターフェースと実装を持つもの。関数、クラス、パッケージ、ファイル。粒度は問わない
-- **インターフェース**: 呼び出し側が知らなければならない全て。型シグネチャだけでなく、暗黙の前提条件・エラーの振る舞い・呼び出し順序も含む
-- **実装**: インターフェースの裏側のコード
-- **深さ**: インターフェースの小ささに対する実装の大きさの比率。大きいほど良い
-- **削除テスト**: そのモジュールを消したと想像する。複雑さが消えるなら、そのモジュールはただのパススルーだった。複雑さが N 箇所の呼び出し側に散らばるなら、そのモジュールは仕事をしていた
+## When to use
 
-## いつ使うか
+- Hunting structural improvement opportunities
+- Turning vague "this feels redundant" into words
+- Tests are hard to write (often signals shallow modules)
 
-- コードベースの構造的な改善機会を探したいとき
-- 「このあたり、なんか冗長だな」という漠然とした違和感を言語化したいとき
-- テストが書きづらいモジュールがあるとき（テストしづらさは shallow module のシグナル）
+Do **not** use during feature work or bug fixes (make it work first), or for diff review (use `self-review`).
 
-使わない場面:
+## Steps
 
-- 機能追加やバグ修正の最中（まず動かしてからリファクタ）
-- 差分レビュー（`self-review` を使う）
+### 1. Explore
 
-## 手順
+Walk the codebase and note **friction** by reading code—not only heuristics:
 
-### 1. 探索する
+- Understanding one concept requires hopping many small modules → possibly over-split
+- Interface complexity ≈ implementation → wrappers, pure delegation, getter/setter piles
+- Tests only cover extracted pure functions while bugs live in composition → lost locality
+- Tightly coupled cluster with mutual internal dependencies → redraw boundaries
+- Untested or hard-to-test modules → bad interface shape
 
-コードベースを歩いて、以下のような **摩擦** を感じる場所をメモする。機械的なヒューリスティクスに頼らず、実際にコードを読んで引っかかる場所を探す。
+Apply the **deletion test** on each candidate.
 
-着目点:
+### 2. Present candidates
 
-- **1 つの概念を理解するために複数の小さなモジュールを行き来する必要がある**: 分割が浅すぎるサイン
-- **インターフェースと実装の複雑さがほぼ同じ**: 典型的な shallow module。ラッパー、委譲だけのクラス、setter/getter の集合
-- **テスタビリティのためだけに純関数を切り出しているが、本当のバグは呼び出し側の組み合わせに潜む**: 局所性（locality）の喪失
-- **密結合したモジュール群が互いの内部に依存している**: 境界の引き直しが必要
-- **テストされていない、またはテストが書きづらいモジュール**: インターフェースの形が悪いシグナル
+Numbered list; each entry includes:
 
-見つけたら **削除テスト** を適用する: そのモジュールを消したら複雑さは集約される？ 散らばる？ 集約されるなら、そのモジュールは仕事をしていない。
+- **Target file/module**
+- **Friction:** what hurts today
+- **Proposal:** what to change (plain language—no concrete API yet)
+- **Benefit:** testability, locality, simpler callers
 
-### 2. 候補を提示する
+**Do not propose concrete interfaces here.** Ask which candidate to deepen.
 
-番号付きリストで提示する。各候補には以下を含める:
+### 3. Deepen the chosen candidate
 
-- **対象ファイル / モジュール**: どこの話か
-- **摩擦**: 現状何が痛いか
-- **提案**: 何をどう変えるか（平文で。インターフェースの具体案はまだ出さない）
-- **得られるもの**: 深くなることで何が良くなるか（テストのしやすさ、変更の局所性、呼び出し側のシンプルさ）
+For the user’s pick, refine design in dialogue:
 
-**インターフェースの具体案はここでは出さない**。ユーザーに「どれを掘り下げる？」と聞く。
+- New interface shape
+- What moves inside the boundary
+- Test survival vs rewrite
+- Can it ship in tiny commits?
 
-### 3. 掘り下げる
+For multiple interface options, hand off to `design-it-twice`.
 
-ユーザーが選んだ候補について、対話で設計を詰める。
+## Notes
 
-- 深くしたモジュールのインターフェースはどうなるか
-- 何が境界の内側に移るか
-- 既存のテストは生き残るか、書き直しが必要か
-- 変更は段階的に（tiny commits で）進められるか
-
-インターフェースの案を複数比較したくなったら `design-it-twice` に渡す。
-
-## 注意
-
-- **探索の結果「改善候補なし」も正しい答え**。無理に見つけようとしない。
-- **「分割すれば良くなる」とは限らない**。分割は shallow module を増やすリスクがある。統合して深くすることの方が多い。
-- **実装に踏み込みすぎない**。候補の提示と設計の議論まで。コードを書くのは別ステップ。
-- **削除テストを省略しない**。「このモジュールは要らないのでは？」という問いを怖がらない。
+- **"No candidates" is valid.**
+- **Splitting is not always better**—merging into a deeper module is often the win.
+- **Stop at design**—implementation is a separate step.
+- **Do not skip the deletion test.**

--- a/.cursor/skills/design-it-twice/SKILL.md
+++ b/.cursor/skills/design-it-twice/SKILL.md
@@ -1,88 +1,84 @@
 ---
 name: design-it-twice
 description: >-
-  モジュールや API のインターフェースを設計するとき、サブエージェントを並列に走らせて根本的に異なる複数案を生成・比較する。
-  最初の案が最善であることはまずない。A Philosophy of Software Design の「Design It Twice」を実践する。
-  Use when designing an API, exploring interface shapes, or the user mentions "design it twice" or "interface comparison".
+  When designing a module or API, run parallel subagents to produce fundamentally
+  different options and compare them. The first idea is rarely best—practice "Design It Twice"
+  from A Philosophy of Software Design. Use when designing an API, exploring interface shapes,
+  or the user mentions "design it twice" or "interface comparison".
 ---
 
-# Design It Twice
+# Design it twice
 
-最初に思いついた設計が最良であることは、まずない。**根本的に異なる複数のインターフェース案を並べ、比較の中から洞察を得る** のがこの skill の目的。
+The first design is rarely the best. **Place radically different interface options side by side** and learn from the contrast.
 
-A Philosophy of Software Design の「Design It Twice」は、代替案を出すこと自体に価値があるという立場。比較しなければ見えないトレードオフが必ずある。
+Comparison surfaces tradeoffs you will not see from a single sketch.
 
-## いつ使うか
+## When to use
 
-- 新しいモジュール・関数・コンポーネントの public interface を決めるとき
-- 既存 API のリデザインを検討するとき
-- 「どういう形にするか」で迷って手が止まったとき
+- Choosing a new module, function, or component public API
+- Redesigning an existing API
+- Stuck on shape ("how should this look?")
 
-使わない場面:
+Do **not** use for internal optimization without API changes, or when the framework dictates the shape.
 
-- 内部実装の最適化（インターフェースを変えない改善は対象外）
-- 設計が既に制約で一意に決まるケース（フレームワークの規約に従うだけ等）
+## Steps
 
-## 手順
+### 1. Clarify requirements
 
-### 1. 要件の整理
+At minimum:
 
-設計の入力を明らかにする。最低でも以下を把握する:
+- **Purpose** in one sentence (if not, scope is too wide)
+- **Callers** (other modules, users, tests)
+- **Main operations** (CRUD, transform, side effects)
+- **Complexity to hide** from callers
+- **Constraints** (performance, consistency, compatibility)
 
-- **何を解決するモジュールか**（1 文で言えるか？言えなければスコープが広すぎる）
-- **呼び出し側は誰か**（他モジュール、ユーザー、テスト）
-- **主要な操作**（CRUD なのか、変換なのか、副作用を伴うか）
-- **隠すべき複雑さ**（呼び出し側が知らなくて済むべきことは何か）
-- **制約**（パフォーマンス、既存パターンとの一貫性、後方互換）
+Ask: "What does this module do? Who uses it? What should callers not need to know?"
 
-ユーザーに聞く: 「このモジュールは何をする？誰が使う？呼び出し側が気にしなくて済むようにしたいのは何？」
+### 2. Generate options in parallel
 
-### 2. 並列で複数案を生成する
+Launch **3+ subagents at once** via Task with **different design constraints** so options do not converge.
 
-Task tool で **3 つ以上のサブエージェントを同時に起動** する。各サブエージェントには **異なる設計制約** を与え、案が似通うことを防ぐ。
+| Agent | Constraint example |
+|-------|-------------------|
+| A | Minimize method count (1–3) |
+| B | Optimize for the most common use case |
+| C | Maximize generality for future uses |
+| D | Borrow from a specific library or paradigm |
 
-制約の例:
+Each agent returns:
 
-| エージェント | 設計制約 |
-|---|---|
-| A | メソッド数を最小にせよ（1〜3 個） |
-| B | 最も頻出するユースケースに特化せよ |
-| C | 汎用性を最大化せよ（将来の用途も受け入れる） |
-| D | [特定のライブラリやパラダイム] から着想を得よ |
+1. **Type-level interface** (signatures, args, returns)
+2. **Caller example** (real usage)
+3. **Hidden complexity**
+4. **Tradeoffs** (gains and costs)
 
-各エージェントには次の出力を求める:
+### 3. Compare in prose
 
-1. **インターフェースの型定義**（シグネチャ、引数、戻り値）
-2. **呼び出し側のコード例**（実際にどう使うか）
-3. **内部に隠す複雑さ**（呼び出し側が知らないこと）
-4. **このアプローチのトレードオフ**（何を得て何を失うか）
+When all options are ready, compare in **prose, not a flat table**—tables hide the important tradeoffs.
 
-### 3. 案を並べて比較する
+**Angles:**
 
-全案が揃ったら、以下の観点で比較する。**表ではなく散文で書く**。表は差異を平坦にしてしまい、本当に重要なトレードオフが埋もれる。
+- **Interface size:** methods, args, things to remember; too small leaks complexity to callers
+- **Depth:** work hidden behind the API vs shallow pass-through
+- **Misuse resistance:** easy correct use; wrong use caught early?
+- **Generality vs focus:** fits today without burdening callers with speculative API
 
-**比較の観点:**
+### 4. Synthesize
 
-- **インターフェースの小ささ**: メソッド数、引数の数、呼び出し側が覚えるべきことの量。小さいほど良いが、小さくしすぎると呼び出し側に複雑さが漏れる
-- **深さ**: インターフェースの裏にどれだけの仕事が隠れているか。小さなインターフェースで大きな仕事をするモジュール（deep module）が理想。インターフェースと実装がほぼ同じ複雑さのモジュール（shallow module）は避ける
-- **誤用のしやすさ**: 正しく使うのは簡単か？間違った使い方はコンパイル時・実行時に弾けるか？
-- **汎用性と特化のバランス**: 今のユースケースにフィットしつつ、想定外の用途も自然に受け入れるか？過度な汎用化で呼び出し側の負担が増えていないか？
+Do not pick one option blindly—**combine insights** from several.
 
-### 4. 合成する
+Ask the user:
 
-最良案をそのまま採用するのではなく、**複数案の洞察を組み合わせる** ことを検討する。
+- Which option fits the main use case best?
+- What would you take from the others?
+- Did comparison change what we thought we were building?
 
-ユーザーに問いかける:
+The last question matters most.
 
-- 「どの案が主要なユースケースに最もフィットする？」
-- 「他の案から取り入れたい要素はある？」
-- 「この比較を通じて、要件の理解で変わったことはある？」
+## Notes
 
-最後の問いが特に重要。比較を経て「そもそも何を作りたかったか」の理解が変わることは珍しくない。
-
-## 注意
-
-- **実装に踏み込まない**。このスキルはインターフェースの形を決めるまで。実装の詳細は次のステップ。
-- **案の数で満足しない**。3 案出しても似通っていれば意味がない。制約の与え方で差異を強制する。
-- **実装コストで評価しない**。「作りやすい」は呼び出し側にとっての良さとは無関係。呼び出し側の体験で比較する。
-- **比較を省略しない**。案を出しただけでは Design It Twice にならない。価値はコントラストの中にある。
+- **Stop at interface design**—implementation comes later.
+- **Count alone is not enough**—three similar options fail the exercise; constraints must force difference.
+- **Do not rank by implementation cost**—rank by caller experience.
+- **Comparison is mandatory**—listing options without contrast is not Design It Twice.

--- a/.cursor/skills/implement-issue/SKILL.md
+++ b/.cursor/skills/implement-issue/SKILL.md
@@ -1,62 +1,62 @@
 ---
 name: implement-issue
 description: >-
-  GitHub Issue を読み、ブランチ作成から実装・コミット・PR 作成まで一気通貫で実行する。
+  Read a GitHub Issue and run branch creation through implementation, commit, and PR.
   Use when the user asks to implement, work on, or execute a GitHub issue
-  (e.g. "#123 を実行して", "Issue #42 を実装して").
+  (e.g. "implement #123", "work on Issue #42").
 ---
 
-# Issue 実装
+# Implement issue
 
-`ai-workflow.mdc` のフロー (方針提示 → 承認 → 実装 → PR) を具体手順に落としたもの。
+Concrete steps for the flow in `ai-workflow.mdc` (plan → approval → implement → PR).
 
-## ワークフロー
+## Workflow
 
-### 1. Issue の読み込み
+### 1. Read the issue
 
 ```bash
 gh issue view <number>
 ```
 
-Issue の背景・要件・受け入れ基準を把握する。
+Understand background, requirements, and acceptance criteria.
 
-### 2. ブランチ作成
-
-```bash
-git fetch origin && git checkout -b cursor/<簡潔な説明>-<Issue番号> origin/main
-```
-
-main への直接コミットはしない。
-
-### 3. 分析と方針提示
-
-- 対象コードを読み、変更の影響範囲を把握する
-- 実装方針を提示し、ユーザーの承認を待つ
-- 不明点があれば推測で進めず質問する
-
-### 4. 実装
-
-承認後、タスクを分解して順に実行する。コーディング規約は `coding-guide` スキルに従う。
-
-### 5. コミット
+### 2. Create a branch
 
 ```bash
-git add <変更ファイル>
-git commit -m "<メッセージ>"
+git fetch origin && git checkout -b cursor/<short-description>-<issue-number> origin/main
 ```
 
-- `git log --oneline -10` で既存のコミットメッセージスタイルを確認し、それに合わせる
-- `closes #<Issue番号>` をメッセージ末尾に含める
+Do not commit directly to `main`.
 
-### 6. Push & PR 作成
+### 3. Analyze and propose a plan
+
+- Read affected code and scope impact
+- Present an implementation plan and wait for approval
+- Ask instead of guessing when unclear
+
+### 4. Implement
+
+After approval, break down tasks and execute. Follow `coding-guide`.
+
+### 5. Commit
+
+```bash
+git add <files>
+git commit -m "<message>"
+```
+
+- Match recent style: `git log --oneline -10`
+- End with `closes #<issue-number>` when appropriate
+
+### 6. Push and open a PR
 
 ```bash
 git push -u origin HEAD
 ```
 
-push 後、`create-pull-request` スキルに従って PR を作成する。
+After push, create the PR per `create-pull-request`.
 
-## 重要
+## Important
 
-- ステップ 4〜6 は承認後に **止まらず一気に完遂** する。途中でユーザーに確認を挟まない。
-- フックがタイムアウトする場合は Shell ツールの `timeout` パラメータを伸ばして再試行する。`--no-verify` は使わない。
+- After approval, **complete steps 4–6 without pausing** for confirmation unless blocked.
+- If hooks time out, increase Shell `timeout` and retry. Do not use `--no-verify`.

--- a/.cursor/skills/project-structure/SKILL.md
+++ b/.cursor/skills/project-structure/SKILL.md
@@ -1,22 +1,19 @@
 ---
 name: project-structure
 description: >-
-  FSD ベースのプロジェクト構造定義。レイヤー依存・スライス構造・命名規約を規定する。
-  Use when creating new directories, moving files between layers, or deciding
-  where to place new modules (e.g. "このコンポーネントはどこに置く？",
-  "ディレクトリ構造を教えて").
+  Feature-Sliced Design (FSD) project layout: layer dependencies, slice structure,
+  and naming conventions. Use when creating directories, moving files between layers,
+  or deciding where to place modules (e.g. "where does this component go?",
+  "explain the directory structure").
 ---
 
-# プロジェクト構造
+# Project structure
 
-Feature-Sliced Design（FSD）をベースにした構造。
-公式: https://feature-sliced.design/
+Feature-Sliced Design (FSD) with a few repo-specific choices. Official reference: https://feature-sliced.design/
 
-公式 FSD を土台にしつつ、一部独自の判断を加えている。該当箇所には注釈あり。
+## Layers
 
-## レイヤー
-
-上から下へのみ依存できる（逆は禁止）。
+Dependencies flow **downward only** (never upward).
 
 ```mermaid
 graph TD
@@ -26,48 +23,46 @@ graph TD
   entities --> shared & contents
 ```
 
-| レイヤー | 役割 |
-|----------|------|
-| `app/` | エントリポイント（Next.js App Router）、グローバル設定、プロバイダー |
-| `widgets/` | 画面上にブロックとして表示する UI 単位（スライス名は具象名: `creation-list` など） |
-| `features/` | 複数 widgets で横断的に再利用される共通機能・UI 部品 |
-| `entities/` | 複数機能で共有するモデル（型・ルール・パス・reader）。**UI なし** |
-| `shared/` | ドメインに依存しないユーティリティ、UI キット |
-| `contents/` | 外部データとの吸収層、DTO、変換（※ 公式 FSD の `shared/api` に相当するが独立レイヤーとして分離） |
+| Layer | Role |
+|-------|------|
+| `app/` | Entry (Next.js App Router), global config, providers |
+| `widgets/` | UI blocks on screen (concrete slice names, e.g. `creation-list`) |
+| `features/` | Cross-widget reusable capabilities and UI pieces |
+| `entities/` | Shared models (types, rules, paths, readers). **No UI** |
+| `shared/` | Domain-agnostic utilities and UI kit |
+| `contents/` | External data boundary, DTOs, transforms (like official `shared/api`, but a separate layer) |
 
-### widgets と features の違い
+### widgets vs features
 
-- `widgets` — 画面に見えるブロック。スライス名は `creation-list` のように具象名で、ドメイン名の親フォルダは置かない
-- `features` — widgets 横断の共通機能。`features/<domain>/<feature-name>/` に配置する（後述）
+- `widgets` — Visible blocks; slice names are concrete (`creation-list`), not domain parent folders
+- `features` — Cross-widget shared behavior under `features/<domain>/<feature-name>/` (below)
 
-例: 記事一覧（`widgets/writing-list`）で `features/creation/creation-card` のカード UI を使う。
+Example: `widgets/writing-list` uses `features/creation/creation-card`.
 
-## features のスライス構造
+## features slice layout
 
-`features/<domain>/` は **整理用ディレクトリのみ**（`index.ts` なし）。Public API は `<feature-name>/index.ts` に置く。
+`features/<domain>/` is **organizational only** (no `index.ts`). Public API lives in `<feature-name>/index.ts`.
 
 ```
-features/creation/              # 束ねるだけ（index.ts なし）
-  creation-card/                # 機能パッケージ
+features/creation/              # grouping only (no index.ts)
+  creation-card/
     ui/creation-card/
       creation-card.tsx
     index.ts
 ```
 
-- **import** — `from ".../features/creation/creation-card"` のように機能パッケージを直指定する
-- 横断基盤（MDX など）は `features/mdx/` 配下にサブ feature を切り、ルート `index.ts` / `index.client.ts` で barrel してよい
+- **import** — `from ".../features/creation/creation-card"` (feature package directly)
+- Cross-cutting infra (e.g. MDX) may live under `features/mdx/` with root `index.ts` / `index.client.ts` barrels
 
-## スライス内の構造（widgets / feature パッケージ）
+## Inside a slice (widgets / feature package)
 
-各スライス（例: `widgets/creation-list/` や `features/creation/creation-card/`）は以下のセグメントを持てる。
+| Segment | Purpose |
+|---------|---------|
+| `ui/` | Components and related hooks, packaged by feature |
+| `models/` | Shared types and helpers |
+| `helpers/` | Other shared utilities |
 
-| セグメント | 内容 |
-|-----------|------|
-| `ui/` | コンポーネントと関連フックを機能単位でパッケージング |
-| `models/` | 共通の型定義、ヘルパー |
-| `helpers/` | その他共通のユーティリティ |
-
-`ui/` 内は機能単位でディレクトリを切り、関連するコンポーネントとフックを一緒に置く（コロケーション）。
+Colocate related components and hooks under `ui/<feature-name>/`.
 
 ```
 widgets/creation-list/
@@ -80,79 +75,77 @@ features/creation/creation-card/
   ui/
     creation-card/
       creation-card.tsx
-  index.ts          ← Public API（creation/ 直下には index.ts なし）
+  index.ts          ← Public API (no index.ts directly under creation/)
 ```
 
-## ルール
+## Rules
 
-### [Must] 上位レイヤーは下位にのみ依存
+### [Must] Upper layers depend on lower layers only
 
-依存の方向を統一し、変更の影響範囲を予測しやすくする。
+Keeps change impact predictable.
 
-### [Must] 各スライスは Public API を通じて公開
+### [Must] Expose slices via Public API
 
-スライスの外部からは Public API 経由でのみアクセスする。内部のファイル構造を直接参照しない。
-Public API を維持すれば内部リファクタリングが呼び出し側に影響しない。
+External code imports only through the Public API, not internal paths.
 
-基本は `index.ts` 1 本。Next.js App Router（RSC）で **Server 専用** と **Client 専用** の export が混在するとビルドエラーになるため、必要なスライスだけエントリを分ける。
+Usually a single `index.ts`. For Next.js App Router (RSC), split entries when **server-only** and **client-only** exports must not mix.
 
-| ファイル | 用途 | 先頭ディレクティブ |
-|----------|------|-------------------|
-| `index.ts` | Client / Server 両方から import できるもの（型、両環境で動く関数） | なし |
-| `index.server.ts` | Server Component・`models` の reader など Server 専用 | なし |
-| `index.client.ts` | Client Component 専用の hook など | `"use client"` 必須 |
+| File | Purpose | Leading directive |
+|------|---------|-------------------|
+| `index.ts` | Usable from both client and server (types, isomorphic helpers) | none |
+| `index.server.ts` | Server Components, readers in `models`, etc. | none |
+| `index.client.ts` | Client-only hooks | `"use client"` required |
 
-**import の使い分け（呼び出し側）**
+**Import rules (callers)**
 
-- Server から Server 専用 API → `from ".../slice/index.server"`
-- Client から Client 専用 API → `from ".../slice/index.client"`
-- どちらからも使う API → `from ".../slice"`（`index.ts`）
+- Server → server-only API: `from ".../slice/index.server"`
+- Client → client-only API: `from ".../slice/index.client"`
+- Either → shared API: `from ".../slice"` (`index.ts`)
 
-**分け方の目安**
+**When to split**
 
-- `useEffect` / ブラウザ API / React hook を export する → `index.client.ts`
-- ビルド時・リクエスト時にだけ動く serializer など → `index.server.ts`
-- 上記を `index.ts` にまとめると、Server 側の `import` だけで Client 境界が伝播しうるので分離する
+- `useEffect`, browser APIs, React hooks → `index.client.ts`
+- Build/request-only serializers → `index.server.ts`
+- Mixing these in `index.ts` can pull client boundaries into server imports
 
-**例（MDX）**
+**Example (MDX)**
 
 ```
 entities/mdx-content/
   index.server.ts    # serializeMDXContent, markupMermaid
 
 features/mdx/
-  content-resolver/  # resolveMDXContent
-  mermaid/           # useMermaid（index.client.ts）
-  twitter/           # useTwitter（index.client.ts）
-  index.ts           # resolve 等の barrel
+  content-resolver/
+  mermaid/           # useMermaid (index.client.ts)
+  twitter/
+  index.ts
   index.client.ts
 ```
 
 ```ts
-// Server（reader）
+// Server (reader)
 import { serializeMDXContent } from "../../../entities/mdx-content/index.server";
 
-// Client（UI）
+// Client (UI)
 import { useMermaid } from "../../../features/mdx/index.client";
 import { resolveMDXContent } from "../../../features/mdx";
 ```
 
-`index.client.ts` / `index.server.ts` は **必要なスライスにだけ** 追加する。全スライスに必須ではない。
+Add `index.client.ts` / `index.server.ts` only where needed—not on every slice.
 
-### [Must] ディレクトリ名・ファイル名は kebab-case
+### [Must] kebab-case for directories and files
 
-### [Should] `index.ts` にコンポーネント本体を書かない
+### [Should] Do not put component bodies in `index.ts`
 
-`index.ts` は re-export 専用。コンポーネント本体は別ファイルに書く。
-エディタのタブや検索結果で `index.ts` だらけになるのを防ぐ。
+`index.ts` is re-export only.
 
-### [Must] `shared` にビジネスロジックを入れない
+### [Must] No business logic in `shared`
 
-- `shared/` — ドメインに依存しないユーティリティのみ（日付操作、汎用 HTTP クライアントなど）
-- `contents/` — 外部との吸収層、DTO、変換（ビジネス知識を含む）
+- `shared/` — domain-agnostic utilities only
+- `contents/` — external boundaries, DTOs, transforms (may include business knowledge)
 
-### [Should] reader は entities、横断 UI は features
+### [Should] readers in entities; cross-cutting UI in features
 
-- **entities** — 型・ルール・パス・`readXxx` などのデータ取得（`index.server.ts`）
-- **features** — 複数 widgets で使う UI 部品や MDX プラグインなど（entity の UI は置かない）
-- **widgets** — 画面ブロック本体。ドメイン名の抽象スライス（`widgets/creation/`）は避け、具象スライス名を使う
+- **entities** — types, rules, paths, `readXxx` (`index.server.ts`)
+- **features** — reusable UI and plugins (not entity UI)
+- **widgets** — screen blocks; avoid abstract domain slices like `widgets/creation/`

--- a/.cursor/skills/suggest-improvement/SKILL.md
+++ b/.cursor/skills/suggest-improvement/SKILL.md
@@ -87,10 +87,15 @@ Show the proposal and wait for approval. **Do not edit agent config or skills wi
 
 After approval, create a **branch separate from main work** and write files only there.
 
+Stash **only if** the working tree has changes (tracked, staged, or untracked). If the tree is clean, do not run `git stash`—a no-op stash can make a later blind `git stash pop` restore the wrong entry.
+
 ```bash
 ORIGINAL_BRANCH=$(git branch --show-current)
 
-git stash --include-untracked
+if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  git stash push -u -m "suggest-improvement: before improvement branch"
+fi
+
 git fetch origin && git checkout -b cursor/improve-<short-lesson-name> origin/main
 
 # Apply approved changes (lint / agent config / skill)
@@ -112,8 +117,9 @@ Then return:
 
 ```bash
 git checkout "$ORIGINAL_BRANCH"
-git stash pop
 ```
+
+Run `git stash pop` **only if** you stashed before creating the improvement branch.
 
 ## Presentation format
 

--- a/.cursor/skills/suggest-improvement/SKILL.md
+++ b/.cursor/skills/suggest-improvement/SKILL.md
@@ -1,155 +1,152 @@
 ---
 name: suggest-improvement
 description: >-
-  タスク完了時に「最初の失敗」と「最終的な解法」を対にして教訓を抽出し、lint ルール・エージェント設定・skill のいずれかに落とす。
-  試行錯誤を経た解決の後に「次は最初からこう動けた」を形式知にする。
-  Use when codifying lessons after trial-and-error, or when the user says "make it a rule", "leave a lesson", "improve this process".
+  After a task, pair "first failure" with "final solution" and codify lessons into
+  lint rules, agent config, or skills. Use when codifying lessons after trial-and-error,
+  or when the user says "make it a rule", "leave a lesson", "improve this process".
 ---
 
-# Suggest Improvement
+# Suggest improvement
 
-タスクが終わったとき、**「もし最初からこれを知っていれば、回り道しなかった」** という知見を抽出して再利用可能な形に残す。試行錯誤を経て辿り着いた解法にこそ、形式知化する価値がある。
+When a task finishes, extract **"if we had known this upfront, we would not have taken the detour"** and make it reusable. Lessons learned through trial and error are especially worth codifying.
 
-## いつ使うか
+## When to use
 
-- タスク完了直前、または「教訓を残して」「ルールにして」と言われたとき
-- 最初の試みで失敗し、試行錯誤を経て解決に至ったとき
-- 将来同じ種類のタスクを再びやる可能性があるとき
+- Near task completion, or when asked to "leave a lesson" / "make it a rule"
+- After an initial attempt failed and you reached a solution through iteration
+- When similar work is likely to happen again
 
-使わない場面:
+Do **not** use when:
 
-- 初手で通ったシンプルなタスク（抽出すべき教訓がない）
-- プロジェクト固有の一回限りの対応（コミットメッセージで十分）
+- The task succeeded on the first try with nothing to extract
+- A one-off, project-specific fix (a commit message is enough)
 
-## 手順
+## Steps
 
-### 1. 失敗と成功を対にする
+### 1. Pair failure and success
 
-今回のタスクから次の 3 点を書き出す:
+Write:
 
-- **最初の試み**: 何をやって、どう失敗したか
-- **最終的な解法**: 何が正解だったか
-- **橋渡しの知見**: なぜ最初の試みでは辿り着けなかったか
+- **First attempt**: what you tried and how it failed
+- **Final solution**: what actually worked
+- **Bridge insight**: why the first attempt could not reach the solution
 
-### 2. 「最初から知っておくべきだったこと」を言語化する
+### 2. State what should have been known upfront
 
-知見を 1〜3 文に凝縮する。**振り返りではなく、未来の自分への指示** として書く。「〜しない」「先に〜を確認する」のような命令形。
+Condense to 1–3 sentences as **instructions to future you**. Prefer imperatives: "do not …", "check … first".
 
-### 3. 出力先を分類する
+### 3. Classify the output
 
-| 判定軸 | 出力先 | 例 |
-|---|---|---|
-| コードの構文レベルで機械的に検出可能 | lint ルール（ESLint / ast-grep 等） | 「`Array.from(set).length` ではなく `set.size` を使う」 |
-| 短い一文で、常に適用、判断不要 | エージェント設定ファイル（グローバルまたはプロジェクト） | 「pnpm は v10 以上を使う」 |
-| 手順・文脈判断・テンプレートを伴う | 新規 skill または既存 skill に追記 | 「MoonBit の C バインディングの書き方」 |
-| プロジェクト固有の一回限り | 採用しない（コミットメッセージ / PR で十分） | — |
+| Criterion | Destination | Example |
+|-----------|-------------|---------|
+| Detectable mechanically at syntax level | Lint (ESLint, ast-grep, etc.) | Use `set.size` instead of `Array.from(set).length` |
+| One short line, always on, no judgment | Agent config (global or project) | "Use pnpm v10+" |
+| Procedure, context, templates | New or existing skill | "How to write MoonBit C bindings" |
+| One-off project-specific | Skip (commit/PR is enough) | — |
 
-**原則: lint で拾えるものはプロンプトに書かない。** 静的に検出できることを自然言語で書いても、エージェントは従わない。
+**Principle: if lint can catch it, do not put it in prose.** Agents ignore natural-language duplicates of static checks.
 
-「エージェント設定ファイル」はツールによって異なる（Cursor: `.cursor/rules/`、Claude Code: `CLAUDE.md` 等）。プロジェクトの構成に合わせること。
+"Agent config" varies by tool (Cursor: `.cursor/rules/`, Claude Code: `CLAUDE.md`, etc.). Match this project.
 
-### 4. 重複チェック（必須）
+### 4. Duplicate check (required)
 
-提案する前に既存の知識と照合する。重複や類似があれば「新規追加」ではなく「既存に追記」を選ぶ。
+Before proposing, search existing knowledge. Prefer **append** over **new** when similar content exists.
 
-知見からキーワードを 2〜3 個抽出し、以下を検索する:
+Extract 2–3 keywords and search:
 
-- グローバルのスキル置き場（`~/.cursor/skills/`、`~/.claude/skills/` 等）
-- プロジェクトのエージェント設定（`.cursor/rules/`、`CLAUDE.md` 等）
-- プロジェクトの lint ルール設定
+- Global skill dirs (`~/.cursor/skills/`, `~/.claude/skills/`, etc.)
+- Project agent config (`.cursor/rules/`, `CLAUDE.md`, etc.)
+- Lint config
 
-結果を 4 段階に分類する:
+Classify:
 
-- **新規**: ヒットなし → 通常の提案
-- **追記**: 関連する skill / ルールが存在し、新情報が補完的 → 「既存に追記」で提案
-- **重複**: 既存が同じ知見を完全にカバー済み → 提案なし（重複検出の記録だけ残す）
-- **判断不能**: エージェントでは判別できない → ユーザーに判断を委ねる
+- **New**: no hit → normal proposal
+- **Append**: related rule/skill exists and new info complements it
+- **Duplicate**: already fully covered → no proposal (record the duplicate check only)
+- **Unclear**: cannot decide → ask the user
 
-### 5. 提案内容を準備する
+### 5. Prepare proposal text
 
-出力先のフォーマットに従って提案内容を **テキストとして用意する**。この段階ではファイルへの書き出しは行わない（ステップ 7 でまとめて行う）。
+Prepare content as **text only**—do not write files yet (step 7 writes after approval).
 
-**lint ルールの場合**: ルール定義とテストケース（valid / invalid）をセットで書く。
+**Lint:** include rule definition and valid/invalid test cases.
 
-**エージェント設定の場合**: 理由を括弧で添える。
+**Agent config:** add brief rationale in parentheses.
 
 ```markdown
-- pnpm は v10 以上を使う（理由: lockfile 形式が v9 以前と非互換で CI 差分が出る）
+- Use pnpm v10 or newer (lockfile format differs on v9 and below, causing CI drift)
 ```
 
-**skill の場合**: frontmatter + 「いつ使うか」+「手順」+「注意」の構成で書く（既存スキルのスタイルに合わせる）。
+**Skill:** frontmatter + when to use + steps + caveats, matching existing skill style.
 
-### 6. ユーザーの承認を得る
+### 6. Get user approval
 
-準備した提案内容を見せて承認を受ける。**承認なしにエージェント設定や skill を書き換えない**。却下されたらセッションメモとして残すに留める。
+Show the proposal and wait for approval. **Do not edit agent config or skills without approval.** If rejected, keep notes in the session only.
 
-### 7. 別ブランチで変更をコミットする
+### 7. Commit on a separate branch
 
-承認後、**メイン作業とは別ブランチ** を作成し、そのブランチ上でのみファイルへ書き出す。
+After approval, create a **branch separate from main work** and write files only there.
 
 ```bash
-# 現在のブランチ名を記録
 ORIGINAL_BRANCH=$(git branch --show-current)
 
-# main から改善用ブランチを作成
 git stash --include-untracked
-git fetch origin && git checkout -b cursor/improve-<知見を端的に表す名前> origin/main
+git fetch origin && git checkout -b cursor/improve-<short-lesson-name> origin/main
 
-# 承認された改善をファイルに反映（lint ルール / エージェント設定 / skill）
-# ... ファイル編集 ...
+# Apply approved changes (lint / agent config / skill)
+# ... edit files ...
 
-# コミット
-git add <変更ファイル>
-git commit -m "<改善内容を端的に示すメッセージ>"
+git add <files>
+git commit -m "<short improvement message>"
 ```
 
-### 8. PR を作成し、元のブランチに戻る
+### 8. Open a PR and return to the original branch
 
 ```bash
 git push -u origin HEAD
 ```
 
-push 後、`create-pull-request` スキルに従って PR を作成する。PR 本文の **課題** には「タスク中に発見した教訓の形式知化」と書き、**解決法** に振り返りの要約を含める。
+After push, create a PR per `create-pull-request`. In **Problem**, note codifying a lesson from the task; in **Solution**, include the retrospective summary.
 
-PR 作成後、元のブランチに復帰する:
+Then return:
 
 ```bash
 git checkout "$ORIGINAL_BRANCH"
 git stash pop
 ```
 
-## 提示フォーマット
+## Presentation format
 
 ```markdown
-## 振り返り
+## Retrospective
 
-- 最初の失敗: <1 行>
-- 最終的な解法: <1 行>
-- 知見: <1 行>
+- First failure: <one line>
+- Final solution: <one line>
+- Insight: <one line>
 
-## 提案
+## Proposal
 
-採用候補:
-- [lint] <ルール名>: <1 行>
-- [skill 追記] <既存 skill 名>: <1 行>
-- [skill 新規] <skill 名>: <1 行>
-- [rule] エージェント設定 (global/project): <1 行>
+Candidates:
+- [lint] <rule name>: <one line>
+- [skill append] <existing skill>: <one line>
+- [skill new] <skill name>: <one line>
+- [rule] agent config (global/project): <one line>
 
-重複検出（提案なし）:
-- <既存の skill/ルール名> が同一の知見をカバー済み → 追加なし
+Duplicate (no proposal):
+- <existing skill/rule> already covers this → no addition
 
-不採用:
-- <1 行の理由>（例: プロジェクト固有 / lint で表現困難 / 他の教訓に吸収）
+Declined:
+- <one-line reason> (e.g. project-specific / hard to express in lint / absorbed elsewhere)
 
-採用する項目を番号または名前で指定してください。提案なしも正しい結論です。
+Reply with item numbers or names to adopt. "No proposal" is valid.
 ```
 
-教訓が複数ある場合は振り返りブロックを複数置き、提案の各行に「from 教訓 N」を添える。採用候補・重複検出・不採用のうち、該当がない区分は省略する。
+For multiple lessons, use multiple retrospective blocks and tag proposal lines with "from lesson N". Omit empty sections.
 
-## 注意
+## Notes
 
-- **失敗の記述を省略しない**。最終解法だけ書くと、未来の自分が同じ落とし穴にはまる。失敗と成功が対でなければ教訓にならない。
-- **粒度が細かすぎないか確認する**。特定の関数名やバージョン番号をそのまま残すのではなく、「何を確認すべきか」のレベルに抽象化する。
-- **承認なしに書き出さない**。エージェント設定や skill を勝手に変更すると、将来の挙動が予測できなくなる。
-- **提案ゼロも正しい答え**。教訓が薄いのに何か書こうとするのは虚栄。空の振り返りは害にならない。
-- **メイン作業のブランチを汚さない**。改善は必ず別ブランチ・別 PR で提出する。元ブランチに未コミットの変更がある場合は `git stash` で退避してから作業し、完了後に復帰する。
+- **Do not skip describing failure.** Solution-only notes invite the same trap.
+- **Avoid overly specific grains.** Abstract to "what to verify", not raw version numbers.
+- **Do not write without approval.**
+- **Zero proposals is valid.** Do not invent thin lessons.
+- **Do not dirty the main feature branch.** Stash if needed, branch, PR, then return.

--- a/.cursor/skills/tune-prompt/SKILL.md
+++ b/.cursor/skills/tune-prompt/SKILL.md
@@ -1,158 +1,153 @@
 ---
 name: tune-prompt
 description: >-
-  agent 向けの指示（skill / エージェント設定 / タスクプロンプト等）を、
-  白紙のエージェントに実行させて品質を検証し、伝わらなかった箇所を修正するサイクルを回す。
-  プロンプトや skill を作った直後、またはエージェントが期待通りに動かないときに使う。
-  Use when tuning prompts or skills empirically with fresh executors and measurable criteria.
+  Run agent instructions (skills, rules, task prompts) on fresh agents, measure
+  quality, and fix what did not land. Use when tuning prompts or skills empirically
+  with fresh executors and measurable criteria, or right after creating/revising a skill.
 ---
 
-# Tune Prompt
+# Tune prompt
 
-対象のプロンプトや skill を **白紙のエージェントに実行させ、伝わらなかった箇所を特定して修正する** サイクルを回す。評価は「実行者の自己申告（どこで詰まったか）」と「要件チェックリストの達成率」の両面で行う。自分で読み返すのではなく、必ず別のエージェントに渡す。
+Run the target prompt or skill on a **fresh agent**, find what did not land, and fix it. Evaluate both the executor’s report (where they got stuck) and a requirements checklist. **Do not** self-review the text you just wrote—always use another agent.
 
-## いつ使うか
+## When to use
 
-- skill やプロンプトを新規作成・大幅改訂した直後
-- エージェントが期待通り動かず、指示の曖昧さが原因かもしれないとき
-- よく使う skill を堅牢にしたいとき
+- Right after creating or heavily revising a skill or prompt
+- When agents misbehave and ambiguous instructions may be the cause
+- To harden frequently used skills
 
-使わない場面:
+Do **not** use when:
 
-- 一回限りの使い捨てプロンプト（評価コストが割に合わない）
-- 書き手の好みを反映したいだけのとき（品質改善が目的でない）
+- One-off disposable prompts (cost > benefit)
+- You only want stylistic preference, not quality
 
-## 前提
+## Prerequisites
 
-- Task tool やサブエージェント等、**新規コンテキストのエージェントを起動できる** こと。起動できない環境ではこのスキルは適用しない（ユーザーに別チャットでの実行を依頼するか、スキップを報告する）。
-- 自分で読み返して代替するのは **NG**。書いた直後の文章にはバイアスが入るため、評価結果を信用できない。
+- You can spawn agents with a **clean context** (Task tool, subagents, etc.). If not, ask the user to run in another chat or report that this skill cannot apply.
 
-## 準備
+## Preparation
 
-### 対象プロンプトの事前チェック
+### Pre-flight on the target prompt
 
-実行者に渡す前に、対象プロンプトの **frontmatter `description` と本文の整合性** を確認する。description が「A と B ができる」と謳っているのに、本文が A しかカバーしていない場合、実行者は description に引きずられて skill を「いい感じに解釈」してしまう。先に合わせておく。
+Before handing off, check **frontmatter `description` vs body**. If description promises A and B but the body only covers A, executors will over-interpret. Align them first.
 
-### 評価シナリオの設計
+### Design evaluation scenarios
 
-対象プロンプトを実際に使う場面を **2〜3 個** 想定する。
+Plan **2–3** real usage situations:
 
-- **典型ケース 1 つ**: 最もよくある使い方
-- **エッジケース 1〜2 つ**: 境界条件や例外的な状況
+- **Typical (1):** most common path
+- **Edge (1–2):** boundaries or exceptions
 
-1 つだけだとそのシナリオに最適化されてしまう。最低 2 つ。
+One scenario alone overfits. Minimum two.
 
-### 要件チェックリストの作成
+### Requirements checklist
 
-シナリオごとに、成果物が満たすべき要件を **3〜7 項目** で書く。最低 1 つに `[critical]` をつける。
-
-```
-1. [critical] 出力が指定のフォーマットに従っている
-2. エラーケースが考慮されている
-3. コード例が動作する
-```
-
-- `[critical]` が全て ○ → 成功、1 つでも × → 失敗
-- 精度 = ○ の項目数 / 全項目数（部分的は 0.5 として計算）
-
-シナリオも要件も **事前に固定する**。結果を見てから調整しない。
-
-## 実行サイクル
-
-以下を **不明瞭点がなくなるまで** 繰り返す。
-
-### 1. 新規エージェントに実行させる
-
-Task tool 等で **白紙のエージェント** を起動し、以下を渡す:
+Per scenario, list **3–7** verifiable requirements. Mark at least one `[critical]`.
 
 ```
-あなたは <対象プロンプト名> を初見で読む実行者です。
-
-## 対象プロンプト
-<全文を貼る or パスを指定>
-
-## シナリオ
-<状況設定 1 段落>
-
-## 要件チェックリスト
-1. [critical] <項目>
-2. <項目>
-3. <項目>
-
-## やること
-1. 対象プロンプトに従ってシナリオを実行し、成果物を生成してください。
-2. 終了後、以下のレポートを返してください。
-
-## レポート
-- 成果物: <生成物 or 結果のサマリ>
-- 要件達成: 各項目について ○ / × / 部分的（理由付き）
-- 不明瞭点: プロンプトで詰まった箇所、解釈に迷った文言
-- 裁量補完: 指示になかったが自分で埋めた判断
-- 再試行: 同じ判断をやり直した回数とその理由
+1. [critical] Output follows the specified format
+2. Error cases are considered
+3. Code examples run
 ```
 
-複数シナリオを並列で走らせる場合は、1 メッセージ内で複数の Task を同時に呼ぶ。
+- All `[critical]` pass → success; any fail → failure
+- Score = passed items / total (partial = 0.5)
 
-### 2. レポートを読んで記録する
+**Fix scenarios and requirements before running.** Do not tune them after seeing results.
 
-返ってきたレポートから以下を抜き出す:
+## Execution cycle
 
-- **不明瞭点**: どの記述で詰まったか（改善のヒントはここにある）
-- **裁量補完**: プロンプトに書かれていないが実行者が勝手に判断したこと（暗黙の仕様の発見）
-- **要件達成**: 各項目の ○ / × / 部分的 と精度
-- **再試行回数**: 曖昧な指示のシグナル
+Repeat until ambiguity is gone.
 
-ステップ数（tool_uses）が取得できる場合は記録する。シナリオ間で大きな差がある場合、ステップ数が多いシナリオに対する説明が skill 内に足りていない。
+### 1. Run on a fresh agent
 
-### 3. プロンプトを修正する
+Spawn a **clean-context** agent with:
 
-不明瞭点を **1 テーマ分だけ** 修正する。修正前に「この変更で要件チェックリストのどの項目が改善されるか」を明言する。
+```
+You are an executor reading <prompt name> for the first time.
 
-- 関連する微修正 2〜3 件は 1 回にまとめてよい
-- 無関係な修正は次のサイクルに回す
+## Target prompt
+<full text or path>
 
-### 4. サイクルを続けるか判断する
+## Scenario
+<one paragraph setup>
 
-**次のエージェントには必ず新規を使う**（前回の実行者は改善内容を覚えている）。
+## Requirements checklist
+1. [critical] <item>
+2. <item>
+3. <item>
 
-- **続ける**: 新しい不明瞭点がまだ出ている
-- **止める**: 連続 2 回で新規の不明瞭点が 0、かつ精度改善が +3 ポイント以下
-- **設計を見直す**: 3 回以上回しても不明瞭点が減らない → 修正ではなくプロンプトの構造自体を書き直す
-- **打ち切る**: 改善コストが重要度に見合わなくなったら 80 点で出す
+## Tasks
+1. Follow the prompt for the scenario and produce the artifact.
+2. Return this report:
 
-## 報告フォーマット
+## Report
+- Artifact: <output or summary>
+- Requirements: ○ / × / partial per item (with reasons)
+- Ambiguities: where the prompt blocked you, wording that was unclear
+- Discretion: judgments you made that the prompt did not specify
+- Retries: how often you redid work and why
+```
 
-各サイクルの結果を次の形でユーザーに報告する:
+You may run multiple scenarios in parallel via multiple Tasks in one message.
+
+### 2. Record from the report
+
+Extract:
+
+- **Ambiguities** (hints for edits)
+- **Discretion** (implicit spec you should make explicit)
+- **Requirements** (○ / × / partial and score)
+- **Retries** (signal of vague instructions)
+- **Step count** if available; large gaps between scenarios suggest missing explanations
+
+### 3. Edit the prompt
+
+Fix **one theme per cycle**. State which checklist items the change should improve.
+
+- You may batch 2–3 related micro-edits in one cycle
+- Defer unrelated fixes to the next cycle
+
+### 4. Continue or stop
+
+**Always use a new agent** for the next cycle (prior executors remember your edits).
+
+- **Continue:** new ambiguities appear
+- **Stop:** two consecutive runs with zero new ambiguities and score gain ≤ 3 points
+- **Redesign:** 3+ cycles without fewer ambiguities → restructure, not patch
+- **Cut off:** ship at ~80% when cost outweighs importance
+
+## Reporting format
 
 ```markdown
-## サイクル N
+## Cycle N
 
-### 今回の修正
-- <修正内容 1 行>
+### Edits this cycle
+- <one line>
 
-### 実行結果
-| シナリオ | 成功/失敗 | 精度 | 不明瞭点 | 裁量補完 |
+### Results
+| Scenario | Pass/Fail | Score | Ambiguities | Discretion |
 |---|---|---|---|---|
-| A | ○ | 90% | 0 件 | 0 件 |
-| B | × | 60% | 2 件 | 1 件 |
+| A | ○ | 90% | 0 | 0 |
+| B | × | 60% | 2 | 1 |
 
-### 不明瞭点の詳細
-- <シナリオ B>: [critical] 項目 N が × — <理由>
-- <シナリオ B>: <その他>
+### Ambiguity detail
+- <Scenario B>: [critical] item N failed — <reason>
+- ...
 
-### 裁量補完の詳細
-- <シナリオ B>: <内容>
+### Discretion detail
+- <Scenario B>: <what they invented>
 
-### 次の修正案
-- <1 行>
+### Next edit
+- <one line>
 
-（収束状況: 連続クリア X 回 / 停止条件まであと Y 回）
+(Convergence: X clear runs in a row / Y cycles until stop)
 ```
 
-## 注意
+## Notes
 
-- **自分で読み返して済ませない**。必ず別のエージェントに渡す。
-- **シナリオは最低 2 つ**。1 つだとそのシナリオへの過適合を見逃す。
-- **1 サイクル 1 テーマ**。複数を一気に直すと何が効いたか追えなくなる。
-- **数値だけ追わない**。精度やステップ数の改善だけを目的にすると、必要な説明が削られて脆くなる。不明瞭点と裁量補完を主に見る。
-- **シナリオを結果に合わせない**。不明瞭点を消すためにシナリオを簡単にするのは本末転倒。
+- **Never substitute self-review for a fresh agent.**
+- **At least two scenarios.**
+- **One theme per cycle.**
+- **Do not optimize numbers alone**—ambiguities and discretion matter more than score/steps.
+- **Do not simplify scenarios** to clear ambiguities—that defeats the purpose.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,35 +1,35 @@
-name: 機能要望
-description: 新機能や改善の要望を記載するテンプレート
+name: Feature request
+description: Template for new features and improvements
 labels: []
 body:
   - type: textarea
     id: background
     attributes:
-      label: 背景・目的
-      description: この要望を出すに至った背景や目的を記載してください
-      placeholder: "例: ユーザーが〇〇をしたい時に、現在は△△という手順が必要で不便に感じているため..."
+      label: Background & purpose
+      description: Describe the background and purpose behind this request
+      placeholder: "e.g. When users want to do X, they currently need to Y, which is inconvenient..."
     validations:
       required: true
 
   - type: textarea
     id: requirements
     attributes:
-      label: 要件・要望の詳細
-      description: 実現したい機能や改善内容を具体的に記載してください
+      label: Requirements & details
+      description: Describe the feature or improvement you want in concrete terms
       placeholder: |
-        例:
-        - 〇〇ができるようにする
-        - △△の操作を簡略化する
-        - ××の情報を表示する
+        e.g.
+        - Enable users to do X
+        - Simplify the Y workflow
+        - Show Z information
     validations:
       required: true
 
   - type: textarea
     id: acceptance_criteria
     attributes:
-      label: 受け入れ基準
-      description: この要望が完了したと判断する基準を記載してください（任意）
+      label: Acceptance criteria
+      description: Criteria that define when this request is done (optional)
       placeholder: |
-        例:
-        - [ ] 〇〇が動作すること
-        - [ ] △△のテストが通ること
+        e.g.
+        - [ ] X works as expected
+        - [ ] Tests for Y pass


### PR DESCRIPTION
## Problem

Closes #263

Agent-facing configuration under `.cursor/` was largely written in Japanese, which adds ambiguity for English-tuned models, makes onboarding harder for non-Japanese contributors, and splits concepts across languages. The project needs English as the default working language for agent instructions and repo artifacts.

## Solution

- Translated all files under `.cursor/rules/`, `.cursor/skills/`, and `.cursor/agents/` to English while preserving structure, constraints, and actionable guidance (FSD layout, AI workflow, coding guide, subagent delegation, etc.).
- Added **Communication language** to `ai-workflow.mdc`: agents use English for plans, summaries, issue/PR bodies, commits, and `.cursor/` edits; repo rules override user-level Cursor preferences for those artifacts.
- Added **Agent-facing docs audit** table documenting scope boundaries (what this PR covers vs. out of scope).
- Updated PR body format headings in `create-pull-request` skill and agent to English (Problem / Solution / Design / Impact and risks).
- Intentional Japanese retained only where required: issue template `label` strings in `create-github-issue` skill examples (must match `.github/ISSUE_TEMPLATE` YAML).

## Impact and risks

- **Behavior change:** Agents should now produce English artifacts by default; personal persona rules (e.g. reply in Japanese) no longer apply to repo work outputs.
- **Risk:** Subtle meaning drift during translation could weaken constraints; mitigated by preserving file structure and section headings.
- **Out of scope:** Application UI, README, and closed issues/PRs are unchanged per #263.