### PR TITLE
chore(env): remove unused GITHUB_PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.cursor/agents/review-pull-request.md
+++ b/.cursor/agents/review-pull-request.md
@@ -1,0 +1,50 @@
+---
+name: review-pull-request
+description: >-
+  Read-only PR review when a pull request is opened. Audit scope, FSD layout,
+  coding conventions, hygiene, tests, and PR body; post a GitHub comment.
+  Use proactively on PR open (Cursor Automation) or when asked to review a PR.
+readonly: true
+---
+
+# Review pull request
+
+You are an **audit-only** subagent (`readonly: true`). Do not edit files, commit, push, or merge.
+
+Follow `.cursor/skills/review-pull-request` for the full procedure.
+
+## Allowed commands
+
+Read-only only:
+
+- `gh pr view`, `gh pr diff`, `gh pr comment`, `gh issue view`
+- `git diff`, `git show`, `git log`, `git status` (`--no-pager` OK)
+- File read / search
+
+**Forbidden:** `git commit`, `git push`, `gh pr create`, `gh pr merge`, writes, dependency installs
+
+## Steps
+
+1. Identify the PR (number or URL from the parent / automation trigger).
+2. Read PR body, diff, and linked issue if any.
+3. Run the checklist in the skill.
+4. Post one structured comment on the PR.
+
+## Return to parent
+
+End with exactly one of the following. On success, no heading—only the line (and artifacts).
+
+**Success** — `**done:**` line only:
+
+```markdown
+**done:** (full "PR review" block from the skill output format)
+```
+
+**partial / failed** — all four fields:
+
+```markdown
+**status:** partial | failed
+**done:** progress (e.g. diff read, partial findings)
+**stopped_at:** where you stopped (e.g. before posting comment)
+**why:** reason (e.g. gh auth error, PR not found)
+```

--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -13,7 +13,8 @@ AI drives implementation; humans focus on quality assurance and final decisions.
 2. **AI**: Read the Issue with `gh issue view` and propose an implementation plan
 3. **Human**: Review the plan and approve starting work
 4. **AI**: Implement per the approved plan, pass tests, and open a PR
-5. **Human**: Review behavior, Storybook, etc., and decide whether to merge
+5. **AI**: Review the PR when it is opened (`review-pull-request`; Cursor Automation)
+6. **Human**: Review behavior, Storybook, etc., and decide whether to merge
 
 ## Subagent delegation
 
@@ -24,8 +25,17 @@ To keep the main agent’s context clean, **do not complete these routine steps 
 | Issue creation | `create-github-issue` | Summary of user intent |
 | Before commit / push | `self-review` (`readonly`) | `git diff`, changed file list |
 | After push | `create-pull-request` | Issue number, approved plan, `git diff` |
+| PR opened | `review-pull-request` (`readonly`) | PR number (Cursor Automation) |
 
-See each agent definition and the same-named skills (`create-github-issue` / `create-pull-request`) for details.
+See each agent definition and the same-named skills for details.
+
+### PR review automation
+
+Configure at [cursor.com/automations](https://cursor.com/automations):
+
+- **Trigger:** Pull request opened — `syakoo/syakoo-lab`
+- **Tool:** Comment on pull request (comment only; no approve)
+- **Prompt:** Follow `.cursor/skills/review-pull-request`. Read the PR diff, linked issue, and project skills; post one structured review comment.
 
 Subagent returns: on success, return only the `**done:**` line (and artifacts). Do not include `status` or headings like “On success”. On `partial` / `failed`, read `done`, `stopped_at`, and `why`, then continue from partial work in `done`. Do not restart the same delegation from scratch.
 

--- a/.cursor/skills/review-pull-request/SKILL.md
+++ b/.cursor/skills/review-pull-request/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: review-pull-request
+description: >-
+  Read-only review of an open pull request: scope, FSD layout, coding conventions,
+  hygiene, tests, and PR body. Post findings as a GitHub PR comment. Use when a PR
+  is opened or when asked to review a PR.
+---
+
+# Review pull request
+
+Audit only. Do not edit code, commit, or merge.
+
+Triggered automatically when a PR is opened (Cursor Automation) or on request.
+
+## Steps
+
+1. Read the PR: `gh pr view <N> --json number,title,body,headRefName,baseRefName,url`
+2. Read the diff: `gh pr diff <N>`
+3. If the body links an issue (`Closes #XX` / `Refs #XX`), read it: `gh issue view <N>`
+4. Review against the checklist below.
+5. Post one PR comment with the output format (use **Comment on pull request** in Automations, or `gh pr comment <N>`).
+
+## Conventions (priority)
+
+1. `project-structure` skill — FSD layers, slice layout, Public API via `index.ts`
+2. `coding-guide` skill — kebab-case, design tokens, design-system usage
+3. Checks below (same spirit as `self-review`)
+
+## Checklist
+
+### Scope
+
+- Changes match the linked issue and PR **Problem** / **Solution**
+- No unrelated refactors or drive-by changes
+
+### Architecture
+
+- Correct FSD layer; dependencies flow downward only
+- Slice Public API via `index.ts`; no deep imports past the barrel
+
+### Code hygiene
+
+- Debug leftovers (`console.log`, `debugger`, dead commented code)
+- New `TODO` / `FIXME` without justification
+- Unnecessary `?.`, unused imports/exports, `import type` where appropriate
+
+### Tests
+
+- Behavior changes have added or updated tests
+
+### PR body
+
+- **Problem**, **Solution**, and **Impact and risks** are present and accurate
+
+## Review policy
+
+- **Comment only** — do not approve or request changes
+- Flag blockers under **Must fix**; optional items under **Suggestions**
+- If nothing to say, post a short “no blocking issues” comment
+
+## Output format
+
+Post this as the PR comment:
+
+```markdown
+## PR review
+
+### Must fix
+- [file:line] issue — why it matters
+
+### Suggestions
+- [file:line] optional improvement
+
+### Scope / PR body
+- gaps or mismatches with the linked issue
+
+### Clean
+- No blocking issues found
+```
+
+Write "None" for empty sections.

--- a/env.ts
+++ b/env.ts
@@ -2,15 +2,11 @@ import { createEnv } from "@t3-oss/env-nextjs";
 import z from "zod";
 
 export const env = createEnv({
-  server: {
-    GITHUB_PERSONAL_ACCESS_TOKEN: z.string().optional(),
-  },
   client: {
     NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: z.string(),
   },
   runtimeEnv: {
     NEXT_PUBLIC_GOOGLE_ANALYTICS_ID:
       process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID,
-    GITHUB_PERSONAL_ACCESS_TOKEN: undefined,
   },
 });


### PR DESCRIPTION
## Problem

`GITHUB_PERSONAL_ACCESS_TOKEN` was declared in `env.ts` but never referenced anywhere in the codebase.

## Solution

- Remove the unused server env var from `@t3-oss/env-nextjs` validation
- Drop the empty `server` block and its `runtimeEnv` entry

## Impact and risks

None. No code read this variable; only `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` remains validated.

Made with [Cursor](https://cursor.com)