### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Syakoo Lab is a single **Next.js 16 (App Router) + React 19** statically-exported
+personal website. Content is local MDX/markdown under `src/contents/` — there is
+no backend, database, or external service to run. All commands live in
+`package.json` `scripts`; use those rather than duplicating them here.
+
+### Runtime / toolchain
+
+- The repo pins Node `24.16.0` (`.node-version`) with `engine-strict=true`
+  (`.npmrc`), and pnpm `10.34.1` (`packageManager`). Node <24 fails `pnpm install`.
+- The base VM ships a Node 22 binary at `/exec-daemon/node` that sits early in
+  `PATH`. To make the project's Node 24 win everywhere (including the startup
+  update script and non-interactive shells), Node 24's `node`/`pnpm`/`npm`/`npx`/
+  `corepack` are symlinked into `/usr/local/cargo/bin` (the first, writable `PATH`
+  entry). This is a persisted one-time setup; you should not need to touch nvm.
+  If `node --version` ever shows v22, the symlinks are missing — recreate them
+  from `~/.nvm/versions/node/v24.16.0/bin`.
+
+### Required env var
+
+- Both `pnpm dev` and `pnpm build` require `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`
+  (validated by `env.ts` via `@t3-oss/env-nextjs`). Use any string; a value not
+  starting with `G-` disables real tracking. `.env.test` already sets
+  `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=dummy-ga-id`. Export it inline when running,
+  e.g. `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=dummy-ga-id pnpm dev`.
+
+### Running / checks
+
+- Dev server: `pnpm dev` (Next dev on port 3000).
+- Static build: `pnpm build` → `out/`. The build dumps large CSS strings to
+  stderr while jsdom parses Mermaid/MDX HTML — this is harmless noise, not a
+  failure; rely on the exit code and the route table at the end.
+- Checks: `pnpm lint` (Biome), `pnpm type-check` (tsc), `pnpm test` (Vitest).
+- Storybook (optional, component catalog/a11y): `pnpm storybook`, or
+  `pnpm storybook:build` + `pnpm storybook:serve` (port 6006). A11y test runner
+  (`pnpm storybook:test:ci`) additionally needs `pnpm exec playwright install chromium`.
+
+### Git hooks
+
+- `pnpm install` runs `prepare`, which wires `.githooks` (pre-push runs lint +
+  tests, commit-msg runs commitlint). Commit messages must follow Conventional
+  Commits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for Syakoo Lab and documents durable, non-obvious setup caveats in a new `AGENTS.md`.

This is a single Next.js 16 / React 19 statically-exported site with file-based MDX content — no backend, DB, or external services. The only repo change is the new `AGENTS.md`; environment setup itself is captured by the VM update script (`pnpm install --frozen-lockfile`) and a persisted one-time toolchain setup.

## What was set up

- Installed Node `24.16.0` (repo pins it; `engine-strict=true` requires it) and pnpm `10.34.1` via corepack.
- Worked around the base VM's Node 22 shim at `/exec-daemon/node` by symlinking Node 24's `node`/`pnpm`/`npm`/`npx`/`corepack` into `/usr/local/cargo/bin` (first, writable `PATH` entry) so the correct versions win in all shells, including the startup update script.
- Installed dependencies via `pnpm install`.

## Verification

- `pnpm lint` — passes (only a Biome schema-version info note).
- `pnpm type-check` — passes.
- `pnpm test` — 37 tests across 8 files pass.
- `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=dummy-ga-id pnpm build` — full static export, 98 routes generated.
- `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=dummy-ga-id pnpm dev` — dev server serves home / writings / writing-detail / creations correctly.

### Walkthrough

[syakoo_lab_dev_walkthrough.mp4](https://cursor.com/agents/bc-412f412f-1724-44b8-bb58-16b72dfc5efa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsyakoo_lab_dev_walkthrough.mp4)

[Home page](https://cursor.com/agents/bc-412f412f-1724-44b8-bb58-16b72dfc5efa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page.webp)
[Writing detail page rendering MDX](https://cursor.com/agents/bc-412f412f-1724-44b8-bb58-16b72dfc5efa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwriting_detail.webp)
[Creations portfolio grid](https://cursor.com/agents/bc-412f412f-1724-44b8-bb58-16b72dfc5efa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreations_grid.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-412f412f-1724-44b8-bb58-16b72dfc5efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-412f412f-1724-44b8-bb58-16b72dfc5efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

