### PR TITLE
Add module design guidance to coding-guide

### DIFF
--- a/.cursor/skills/coding-guide/SKILL.md
+++ b/.cursor/skills/coding-guide/SKILL.md
@@ -12,6 +12,14 @@ description: >-
 
 Follow the `project-structure` skill.
 
+## Module design
+
+Prefer **deep modules**: a small public surface with substantial work hidden inside. Callers should not need to know implementation details.
+
+- Public access to a slice stays on **`index.ts` only** (see Component rules)
+- When choosing a new or redesigned API shape, follow `design-it-twice`
+- For a dedicated pass to hunt shallow structure across the codebase, follow `deepen-modules` (not during feature or bug-fix work)
+
 ## Component rules
 
 ### File layout

--- a/.cursor/skills/coding-guide/SKILL.md
+++ b/.cursor/skills/coding-guide/SKILL.md
@@ -16,7 +16,7 @@ Follow the `project-structure` skill.
 
 Prefer **deep modules**: a small public surface with substantial work hidden inside. Callers should not need to know implementation details.
 
-- Public access to a slice stays on **`index.ts` only** (see Component rules)
+- Public access to a slice stays on **`index.ts` only** (see `project-structure`)
 - When choosing a new or redesigned API shape, follow `design-it-twice`
 - For a dedicated pass to hunt shallow structure across the codebase, follow `deepen-modules` (not during feature or bug-fix work)
 


### PR DESCRIPTION
## Problem

Deep-module thinking and links to `design-it-twice` / `deepen-modules` lived only in separate skills, so agents following `coding-guide` during implementation did not see them.

## Solution

- Add a **Module design** section to `coding-guide` with the deep-module principle
- Link to `design-it-twice` for new or redesigned API shapes
- Link to `deepen-modules` for dedicated shallow-structure passes (not during feature or bug-fix work)

## Impact and risks

None. Documentation only; no runtime or CI changes.


Made with [Cursor](https://cursor.com)