### PR TITLE
Clarify when to run meta improvement skills

### DIFF
--- a/.cursor/rules/continuous-improvement.mdc
+++ b/.cursor/rules/continuous-improvement.mdc
@@ -5,7 +5,19 @@ alwaysApply: true
 
 # Continuous improvement
 
-When the AI discovers recurring patterns or tacit knowledge during work, it may codify them as rules or skills.
-Submit those changes in a **separate PR** from feature work and merge after human review.
+When work surfaces reusable lessons or shaky instructions, **run the matching meta skill automatically**. Submit codified changes in a **separate PR** from feature work and merge after human review.
 
-Follow the `suggest-improvement` skill for the detailed procedure and constraints.
+## When to run which skill
+
+| Situation | Skill |
+|-----------|-------|
+| Task needed 2+ attempts, or the first attempt failed before success | `suggest-improvement` — propose only; do not write files without approval |
+| User asks to codify a lesson ("make it a rule", "leave a lesson", etc.) | `suggest-improvement` |
+| Created or heavily revised a skill, rule, or agent prompt | `tune-prompt` — at minimum offer a tune cycle |
+| Agents misbehave on instructions you just wrote; ambiguous prompts suspected | `tune-prompt` |
+
+Do **not** run `suggest-improvement` when the task succeeded on the first try with nothing to extract.
+
+Do **not** run `tune-prompt` for one-off stylistic preferences or disposable prompts.
+
+Follow each skill for the full procedure and constraints.

--- a/.cursor/rules/continuous-improvement.mdc
+++ b/.cursor/rules/continuous-improvement.mdc
@@ -16,6 +16,8 @@ When work surfaces reusable lessons or shaky instructions, **run the matching me
 | Created or heavily revised a skill, rule, or agent prompt | `tune-prompt` — at minimum offer a tune cycle |
 | Agents misbehave on instructions you just wrote; ambiguous prompts suspected | `tune-prompt` |
 
+When trial-and-error produces a new or heavily revised skill, run `suggest-improvement` first (propose the lesson), then offer `tune-prompt` on the written prompt if needed.
+
 Do **not** run `suggest-improvement` when the task succeeded on the first try with nothing to extract.
 
 Do **not** run `tune-prompt` for one-off stylistic preferences or disposable prompts.

--- a/.cursor/skills/suggest-improvement/SKILL.md
+++ b/.cursor/skills/suggest-improvement/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: suggest-improvement
 description: >-
-  After a task, pair "first failure" with "final solution" and codify lessons into
-  lint rules, agent config, or skills. Use when codifying lessons after trial-and-error,
-  or when the user says "make it a rule", "leave a lesson", "improve this process".
+  After a task where the first attempt failed, pair failure with final solution and
+  propose codifying the bridge insight into lint, rules, or skills. Use near task
+  completion after trial-and-error, or when the user asks to "make it a rule" or
+  "leave a lesson". NOT for empirically testing instructions on fresh agents
+  (tune-prompt) or writing new skills from scratch (create-skill).
 ---
 
 # Suggest improvement
@@ -12,7 +14,7 @@ When a task finishes, extract **"if we had known this upfront, we would not have
 
 ## When to use
 
-- Near task completion, or when asked to "leave a lesson" / "make it a rule"
+- Near task completion after trial-and-error, or when asked to "leave a lesson" / "make it a rule"
 - After an initial attempt failed and you reached a solution through iteration
 - When similar work is likely to happen again
 

--- a/.cursor/skills/suggest-improvement/SKILL.md
+++ b/.cursor/skills/suggest-improvement/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: suggest-improvement
 description: >-
-  After a task where the first attempt failed, pair failure with final solution and
-  propose codifying the bridge insight into lint, rules, or skills. Use near task
-  completion after trial-and-error, or when the user asks to "make it a rule" or
-  "leave a lesson". NOT for empirically testing instructions on fresh agents
-  (tune-prompt) or writing new skills from scratch (create-skill).
+  Propose codifying reusable lessons from trial-and-error or explicit user
+  requests into lint, rules, or skills. Use near task completion after failed
+  first attempts, or when the user asks to "make it a rule" or "leave a lesson".
+  NOT for empirically testing instructions on fresh agents (tune-prompt) or
+  drafting a new skill without a lesson to codify.
 ---
 
 # Suggest improvement

--- a/.cursor/skills/tune-prompt/SKILL.md
+++ b/.cursor/skills/tune-prompt/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   edit one theme per cycle until instructions land. Use after creating or heavily
   revising agent instructions, when agents misbehave on those instructions, or when
   validating that a skill is followed correctly. NOT for codifying runtime lessons
-  after task failures (suggest-improvement) or authoring new skills from scratch
-  (create-skill).
+  after task failures (suggest-improvement) or drafting a new skill without empirical
+  validation.
 ---
 
 # Tune prompt

--- a/.cursor/skills/tune-prompt/SKILL.md
+++ b/.cursor/skills/tune-prompt/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: tune-prompt
 description: >-
-  Run agent instructions (skills, rules, task prompts) on fresh agents, measure
-  quality, and fix what did not land. Use when tuning prompts or skills empirically
-  with fresh executors and measurable criteria, or right after creating/revising a skill.
+  Empirically test skills, rules, or prompts on fresh agents with scored checklists;
+  edit one theme per cycle until instructions land. Use after creating or heavily
+  revising agent instructions, when agents misbehave on those instructions, or when
+  validating that a skill is followed correctly. NOT for codifying runtime lessons
+  after task failures (suggest-improvement) or authoring new skills from scratch
+  (create-skill).
 ---
 
 # Tune prompt


### PR DESCRIPTION
## Problem

`suggest-improvement` and `tune-prompt` overlapped in when-to-use guidance, so agents could pick the wrong meta skill or skip one after revising instructions.

## Solution

- Expand `continuous-improvement.mdc` with a when-to-run table and explicit do-not-run cases
- Tighten skill descriptions for `suggest-improvement` and `tune-prompt` with boundaries between each other and `create-skill`

## Impact and risks

None. Agent documentation only; no runtime or CI changes.


Made with [Cursor](https://cursor.com)