### PR TITLE
Restrict re-exports to the slice public-API barrel in coding-guide

### DIFF
--- a/.cursor/skills/coding-guide/SKILL.md
+++ b/.cursor/skills/coding-guide/SKILL.md
@@ -17,6 +17,7 @@ Follow the `project-structure` skill.
 Prefer **deep modules**: a small public surface with substantial work hidden inside. Callers should not need to know implementation details.
 
 - Public access to a slice stays on **`index.ts` only** (see `project-structure`)
+- Keep re-exports in the slice public-API barrel (`index.ts` / `index.server.ts` / `index.client.ts`) only. Do not add intermediate re-export-only files inside a slice (e.g. a `types.ts` that merely re-exports another module)—import from the original source directly, including downward into `contents/`
 - When choosing a new or redesigned API shape, follow `design-it-twice`
 - For a dedicated pass to hunt shallow structure across the codebase, follow `deepen-modules` (not during feature or bug-fix work)
 


### PR DESCRIPTION
## Problem

Codifies a lesson from review on #291. While addressing PR feedback, a non-`index.ts` re-export file (`about-me/types.ts` that only re-exported a `contents/` type) was removed in favor of importing from the source directly. The existing skills only state that `index.ts` is re-export-only (no bodies); they did not say re-exports should live **only** in the slice public-API barrel. That gap is what let the redundant re-export file appear in the first place.

## Solution

- Append one bullet to `coding-guide` (Module design): keep re-exports in the slice public-API barrel (`index.ts` / `index.server.ts` / `index.client.ts`) only; do not add intermediate re-export-only files inside a slice—import from the original source directly, including downward into `contents/`.

## Impact and risks

- Documentation/agent-guidance only; no code or runtime change.

Made with [Cursor](https://cursor.com)