### PR TITLE
Add version-up skill and wire release + health-checkup cycle into the workflow

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -27,7 +27,7 @@ flowchart TD
   E --> F["👤 review + feedback"]
   F --> G["🤖 address review"]
   G --> H["👤 merge"]
-  H --> I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
+  H -->|periodically, after merges accumulate| I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
   I --> J["🤖 health-checkup"]
   J --> A
   L["💡 continuous-improvement"] -.separate PR.-> A
@@ -49,6 +49,12 @@ PRs, which simply follow the same review path above.
 ## Subagents
 
 Delegate routine work via Task. Pass only what the subagent needs.
+
+Delegate a step when it is **part of this flow** (not a self-contained deliverable) **and** its
+intermediate journey doesn't need watching—delegation then just trims context. Keep steps whose
+journey or judgment you want to see in the main agent. That is why `version-up` / `health-checkup`
+(release decision and design-drift findings are the point) are **not** delegated here; see **Release
+cycle**.
 
 | When | Subagent |
 |------|----------|

--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -27,11 +27,24 @@ flowchart TD
   E --> F["👤 review + feedback"]
   F --> G["🤖 address review"]
   G --> H["👤 merge"]
+  H --> I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
+  I --> J["🤖 health-checkup"]
+  J --> A
+  L["💡 continuous-improvement"] -.separate PR.-> A
+  R["🔄 Renovate — dependency PRs (separate)"] -.-> E
 ```
 
 - Do not implement before the plan is approved (`cursor:implement` on the issue).
 - Do not change beyond the approved scope.
 - Implementation steps: `implement-issue` skill. Layout: `project-structure` skill. Language: English.
+
+## Release cycle
+
+Periodically, after merged work accumulates, cut a release of **syakoo-lab itself**: run the
+`version-up` skill (bump this repo's own `package.json` `version` + change summary), which hands off
+to the `health-checkup` skill (design-drift audit). Both run as a dedicated PR, separate from
+feature work. This is the project's own release ritual—distinct from Renovate's dependency-update
+PRs, which simply follow the same review path above.
 
 ## Subagents
 

--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -50,11 +50,9 @@ PRs, which simply follow the same review path above.
 
 Delegate routine work via Task. Pass only what the subagent needs.
 
-Delegate a step when it is **part of this flow** (not a self-contained deliverable) **and** its
-intermediate journey doesn't need watching—delegation then just trims context. Keep steps whose
-journey or judgment you want to see in the main agent. That is why `version-up` / `health-checkup`
-(release decision and design-drift findings are the point) are **not** delegated here; see **Release
-cycle**.
+Delegate only when a step is part of this flow **and** its journey needn't be watched—delegation
+just trims context. Keep steps whose output needs human judgment (`version-up`, `health-checkup`)
+in the main agent.
 
 | When | Subagent |
 |------|----------|

--- a/.cursor/rules/enforcement-inventory.mdc
+++ b/.cursor/rules/enforcement-inventory.mdc
@@ -43,6 +43,7 @@ Routes each standard to its enforcement owner. This is an **index**: rule text l
 | Codify lessons after trial-and-error | Agent | `continuous-improvement` rule |
 | Single source of truth | Agent | `single-source-of-truth` rule |
 | Periodic design checkup | Agent | `health-checkup` skill |
+| Project release / version bump | Agent | `version-up` skill |
 
 ## Config-only exceptions
 

--- a/.cursor/skills/health-checkup/SKILL.md
+++ b/.cursor/skills/health-checkup/SKILL.md
@@ -23,7 +23,7 @@ The audit only works if drift left a trail: every PR logs intentional advisory d
 
 ## Procedure
 
-Triggered by the `version-up` skill at each release; keep the interval small (design debt compounds).
+Run at each release; keep the interval small (design debt compounds).
 
 1. Read advisory deviations logged in PR **Impact and risks** since the last checkup.
 2. Run the `deepen-modules` skill as a structured pass over the areas changed since then.

--- a/.cursor/skills/health-checkup/SKILL.md
+++ b/.cursor/skills/health-checkup/SKILL.md
@@ -23,7 +23,7 @@ The audit only works if drift left a trail: every PR logs intentional advisory d
 
 ## Procedure
 
-Run at each version bump; keep the interval small (design debt compounds).
+Triggered by the `version-up` skill at each release; keep the interval small (design debt compounds).
 
 1. Read advisory deviations logged in PR **Impact and risks** since the last checkup.
 2. Run the `deepen-modules` skill as a structured pass over the areas changed since then.

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: version-up
+description: >-
+  Perform a project release: bump the semver `version` in package.json, summarize
+  changes since the last release, and hand off to the health-checkup. Use when
+  cutting a release, bumping the project version, or asked to "version up" / リリース.
+---
+
+# Version up
+
+The release ritual for **syakoo-lab itself**: bump this project's own `version` in `package.json`
+and run the design checkup that must accompany it.
+
+This is the project's own release, not a dependency update. (Dependency-update PRs are a separate,
+Renovate-automated concern and are out of scope here.)
+
+## When to use
+
+- Cutting a new release of syakoo-lab (changing this repo's `package.json` `version`).
+- Whenever enough merged work has accumulated to warrant a release.
+
+Not for dependency bumps or feature work.
+
+## Procedure
+
+Run as a **dedicated PR, separate from feature work** (consistent with `continuous-improvement`).
+
+1. **Find the last release.** Read the current `version` in `package.json` and locate the previous
+   bump (`git log --oneline -- package.json` or the latest release tag).
+2. **Decide the semver bump.** Choose major / minor / patch from the change set:
+   - major: breaking change to public behavior or APIs
+   - minor: backward-compatible feature
+   - patch: backward-compatible fix or docs/internal only
+3. **Apply the bump.** Update `version` in `package.json` only.
+4. **Write a change summary** since the last release, derived from merged PRs / `git log`. Group by
+   the kind of change (features, fixes, internal) so it doubles as release notes.
+5. **Hand off to `health-checkup`.** Run that skill over everything changed since the last release
+   (design-drift audit + `deepen-modules` pass). The version bump is its trigger.
+6. **Open the release PR** per `create-pull-request`, including the change summary.
+
+## Caveats
+
+- Keep release intervals small: the smaller the window, the cheaper the `health-checkup`
+  (design debt compounds).
+- Do not mix a release bump with feature changes in the same PR.
+- The canonical checkup procedure lives in `health-checkup`; this skill only triggers it.

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -3,7 +3,7 @@ name: version-up
 description: >-
   Perform a project release: bump the semver `version` in package.json, summarize
   changes since the last release, and hand off to the health-checkup. Use when
-  cutting a release, bumping the project version, or asked to "version up" / リリース.
+  cutting a release, bumping the project version, or asked to "version up".
 ---
 
 # Version up


### PR DESCRIPTION
## Problem

Closes #293. syakoo-lab has a `health-checkup` skill meant to run "at each version bump", but there was no codified procedure to actually perform the project's **own** release (`package.json` `version`), and the `ai-workflow` rule/diagram didn't reference any release/checkup cadence.

## Solution

- Add `.cursor/skills/version-up/SKILL.md` — the release ritual for **syakoo-lab itself**: decide/apply the semver bump in this repo's `package.json` `version`, write a change summary since the last release, hand off to `health-checkup`, and run as a dedicated PR (separate from feature work). Explicitly scoped as the project's own release, not Renovate dependency updates.
- Update `.cursor/rules/ai-workflow.mdc` — add a **Release cycle** section linking `version-up` → `health-checkup`, and refresh the mermaid flow to reflect current reality (release cycle, continuous-improvement separate PR, Renovate as a separate dependency-PR path).
- Index the skill in `.cursor/rules/enforcement-inventory.mdc`.
- Respects `single-source-of-truth`: canonical procedure lives in the skill; the rule references it.

## Impact and risks

Docs / agent-guidance only — no code or runtime changes. Lint, architecture, and tests pass.

Made with [Cursor](https://cursor.com)