### PR TITLE
docs(version-up): automate release end-to-end without a review PR

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -27,8 +27,8 @@ flowchart TD
   E --> F["👤 review + feedback"]
   F --> G["🤖 address review"]
   G --> H["👤 merge"]
-  H -->|periodically, after merges accumulate| I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
-  I --> J["🤖 health-checkup"]
+  H -->|periodically, after merges accumulate| I["🤖 version-up — syakoo-lab release, end-to-end on main (no PR)"]
+  I --> J["🤖 health-checkup → issues + release notes"]
   J --> A
   L["💡 continuous-improvement"] -.separate PR.-> A
   R["🔄 Renovate — dependency PRs (separate)"] -.-> E
@@ -40,11 +40,12 @@ flowchart TD
 
 ## Release cycle
 
-Periodically, after merged work accumulates, cut a release of **syakoo-lab itself**: run the
-`version-up` skill (bump this repo's own `package.json` `version` + change summary), which hands off
-to the `health-checkup` skill (design-drift audit). Both run as a dedicated PR, separate from
-feature work. This is the project's own release ritual—distinct from Renovate's dependency-update
-PRs, which simply follow the same review path above.
+Periodically, after merged work accumulates, cut a release of **syakoo-lab itself** with the
+`version-up` skill. It runs **end-to-end in one session with no review PR**: run the `health-checkup`
+skill (design-drift audit) and file issues for actionable findings, then bump this repo's own
+`package.json` `version` directly on `main` via the signed Contents API and publish the GitHub
+Release (notes = PR list + health-checkup summary). This is the project's own release ritual—distinct
+from Renovate's dependency-update PRs, which simply follow the same review path above.
 
 ## Subagents
 

--- a/.cursor/skills/health-checkup/SKILL.md
+++ b/.cursor/skills/health-checkup/SKILL.md
@@ -29,5 +29,3 @@ Run at each release; keep the interval small (design debt compounds).
 2. Run the `deepen-modules` skill as a structured pass over the areas changed since then.
 3. Re-check advisory items in `coding-guide` (Tailwind tokens, Storybook coverage, tests for behavior changes).
 4. File issues for what is worth fixing; address small drift in a dedicated PR, separate from features.
-
-When triggered by a release, this checkup runs inside `version-up`: filed issues are linked from the release notes rather than a release-PR footnote.

--- a/.cursor/skills/health-checkup/SKILL.md
+++ b/.cursor/skills/health-checkup/SKILL.md
@@ -29,3 +29,5 @@ Run at each release; keep the interval small (design debt compounds).
 2. Run the `deepen-modules` skill as a structured pass over the areas changed since then.
 3. Re-check advisory items in `coding-guide` (Tailwind tokens, Storybook coverage, tests for behavior changes).
 4. File issues for what is worth fixing; address small drift in a dedicated PR, separate from features.
+
+When triggered by a release, this checkup runs inside `version-up`: filed issues are linked from the release notes rather than a release-PR footnote.

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: version-up
 description: >-
-  Perform a project release: bump the semver `version` in package.json, summarize
-  changes since the last release, and hand off to the health-checkup. Use when
-  cutting a release, bumping the project version, or asked to "version up".
+  Cut a syakoo-lab release end-to-end in one session: decide the semver bump, run
+  the health-checkup (filing issues for actionable findings), commit the version
+  bump straight to `main` via the signed Contents API, and publish the GitHub
+  Release with notes. No review PR. Use when cutting a release, bumping the project
+  version, or asked to "version up".
 ---
 
 # Version up
@@ -42,14 +44,18 @@ human review; the design audit's output lives in issues + release notes instead 
    automatically) rather than a local `git push`:
    ```bash
    # 1. edit the version field in package.json locally (do NOT git-commit it)
-   # 2. commit the edited file straight to main via the API:
+   # 2. commit the edited file straight to main via the API.
+   #    The Contents API needs single-line base64 (avoid macOS's 76-col wrapping):
+   CONTENT=$(base64 -w0 package.json 2>/dev/null || base64 < package.json | tr -d '\n')
    SHA=$(gh api repos/<owner>/<repo>/contents/package.json --jq .sha)
    gh api -X PUT repos/<owner>/<repo>/contents/package.json \
      -f message="chore: bump version to X.Y.Z" \
      -f sha="$SHA" \
-     -f content="$(base64 < package.json)"
+     -f content="$CONTENT"
    ```
-   No PR is needed: branch protection requires neither review nor status checks.
+   Skipping the PR is only valid while `main` requires neither review nor status checks — verify
+   first with `gh api repos/<owner>/<repo>/branches/main/protection` and fall back to an auto-merge
+   PR if rules have tightened.
 5. **Compose release notes** = auto PR list + health-checkup summary. Generate the PR list first:
    ```bash
    gh api repos/<owner>/<repo>/releases/generate-notes \

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Cut a syakoo-lab release end-to-end in one session: decide the semver bump, run
   the health-checkup (filing issues for actionable findings), commit the version
   bump straight to `main` via the signed Contents API, and publish the GitHub
-  Release with notes. No review PR. Use when cutting a release, bumping the project
-  version, or asked to "version up".
+  Release with notes. No review PR by default. Use when cutting a release, bumping
+  the project version, or asked to "version up".
 ---
 
 # Version up
@@ -25,9 +25,10 @@ Not for dependency bumps or feature work.
 
 ## Procedure
 
-Run **end-to-end in a single session**. There is no review PR: the version bump lands directly on
-`main` and the GitHub Release is published in the same run. The release is mechanical and needs no
-human review; the design audit's output lives in issues + release notes instead of a PR body.
+Run **end-to-end in a single session**. The release is mechanical and needs no human review, so by
+default there is no review PR: the version bump lands directly on `main` and the GitHub Release is
+published in the same run (step 4 has the fallback for when `main` protection requires a PR). The
+design audit's output lives in issues + release notes instead of a PR body.
 
 1. **Find the last release.** Read the current `version` in `package.json` and the latest release tag
    (`gh release list` / `git tag --sort=-creatordate`).
@@ -38,7 +39,8 @@ human review; the design audit's output lives in issues + release notes instead 
 3. **Run `health-checkup`** over everything changed since the last release (design-drift audit +
    `deepen-modules` pass). For each **actionable** finding, file a GitHub issue (`create-github-issue`)
    and record its number. Give declined / intentional findings a one-line rationale (a single tracking
-   issue is fine for grouping structural candidates).
+   issue is fine for grouping structural candidates). If nothing is actionable, file no issues — the
+   release notes' Health-checkup section then simply states "No actionable findings."
 4. **Bump the version on `main`.** Change only the `version` field in `package.json`. `main` requires
    **signed commits**, so commit through the GitHub Contents API (GitHub signs API commits
    automatically) rather than a local `git push`:

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -23,24 +23,51 @@ Not for dependency bumps or feature work.
 
 ## Procedure
 
-Run as a **dedicated PR, separate from feature work** (consistent with `continuous-improvement`).
+Run **end-to-end in a single session**. There is no review PR: the version bump lands directly on
+`main` and the GitHub Release is published in the same run. The release is mechanical and needs no
+human review; the design audit's output lives in issues + release notes instead of a PR body.
 
-1. **Find the last release.** Read the current `version` in `package.json` and locate the previous
-   bump (`git log --oneline -- package.json` or the latest release tag).
-2. **Decide the semver bump.** Choose major / minor / patch from the change set:
+1. **Find the last release.** Read the current `version` in `package.json` and the latest release tag
+   (`gh release list` / `git tag --sort=-creatordate`).
+2. **Decide the semver bump** from the change set since the last tag:
    - major: breaking change to public behavior or APIs
    - minor: backward-compatible feature
    - patch: backward-compatible fix or docs/internal only
-3. **Apply the bump.** Update `version` in `package.json` only.
-4. **Write a change summary** since the last release, derived from merged PRs / `git log`. Group by
-   the kind of change (features, fixes, internal) so it doubles as release notes.
-5. **Hand off to `health-checkup`.** Run that skill over everything changed since the last release
-   (design-drift audit + `deepen-modules` pass). The version bump is its trigger.
-6. **Open the release PR** per `create-pull-request`, including the change summary.
+3. **Run `health-checkup`** over everything changed since the last release (design-drift audit +
+   `deepen-modules` pass). For each **actionable** finding, file a GitHub issue (`create-github-issue`)
+   and record its number. Give declined / intentional findings a one-line rationale (a single tracking
+   issue is fine for grouping structural candidates).
+4. **Bump the version on `main`.** Change only the `version` field in `package.json`. `main` requires
+   **signed commits**, so commit through the GitHub Contents API (GitHub signs API commits
+   automatically) rather than a local `git push`:
+   ```bash
+   # 1. edit the version field in package.json locally (do NOT git-commit it)
+   # 2. commit the edited file straight to main via the API:
+   SHA=$(gh api repos/<owner>/<repo>/contents/package.json --jq .sha)
+   gh api -X PUT repos/<owner>/<repo>/contents/package.json \
+     -f message="chore: bump version to X.Y.Z" \
+     -f sha="$SHA" \
+     -f content="$(base64 < package.json)"
+   ```
+   No PR is needed: branch protection requires neither review nor status checks.
+5. **Compose release notes** = auto PR list + health-checkup summary. Generate the PR list first:
+   ```bash
+   gh api repos/<owner>/<repo>/releases/generate-notes \
+     -f tag_name=vX.Y.Z -f previous_tag_name=v<prev> --jq .body
+   ```
+   Then append a `## Health-checkup` section linking the issues filed in step 3 and noting declined items.
+6. **Publish the release.** Tag + publish in one step (the tag is created on `main` at publish time):
+   ```bash
+   gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes "<composed notes>"
+   ```
 
 ## Caveats
 
 - Keep release intervals small: the smaller the window, the cheaper the `health-checkup`
   (design debt compounds).
-- Do not mix a release bump with feature changes in the same PR.
+- Do not fold feature or fix changes into the bump commit — `version` only.
+- `main` requires **signed commits**; the Contents API path satisfies this. A local `git push` would
+  need GPG/SSH signing configured.
+- The token needs **Issues: write** (file/close issues) and **Contents + Releases: write** (bump +
+  publish).
 - The canonical checkup procedure lives in `health-checkup`; this skill only triggers it.


### PR DESCRIPTION
## Problem

The `version-up` release flow ended at "open a release PR", and tag + GitHub Release were manual follow-ups (done by hand for 6.2.0). The version bump is mechanical and needs no review, so the PR step and manual release were pure ceremony.

## Solution

Rewrite the `version-up` skill so one agent session performs the whole release:

- Decide the semver bump, then run `health-checkup` and **file issues for actionable findings**.
- Bump `version` **directly on `main`** via the GitHub Contents API (produces the signed commit `main` requires) — no review PR, since branch protection requires neither review nor status checks (verified at release time).
- Publish the GitHub Release with notes = auto PR list + a `## Health-checkup` section linking the filed issues.

Role split for the health-checkup artifact:

| Record | Before | After |
|---|---|---|
| Change summary | PR body | Release notes (`generate-notes` PR list) |
| Actionable design debt | PR footnote | GitHub issues (linked from notes) |
| Declined / intentional findings | PR footnote | One-line note + optional tracking issue |

Also aligned the always-applied `ai-workflow.mdc` (no more "dedicated release PR"/pre-bump handoff) and added a `health-checkup` cross-link, per single-source-of-truth.

## Impact and risks

- Docs/skill only — no runtime, CI, or app code changes.
- Direct-to-`main` bump means no CI gate on the bump commit itself; acceptable because each feature PR already passed CI and `version` is the only changed field. Advisory deviation noted per coding-standards.
- The no-PR path is framed as a verified precondition (`branches/main/protection`), with an auto-merge PR fallback if rules tighten.
- Requires the operating token to have Issues + Contents + Releases write.

## Test plan

- [ ] Next release dry-runs cleanly: bump via Contents API lands a signed commit on `main`
- [ ] `gh release create vX.Y.Z --target main` publishes tag + notes in one step
- [ ] Release notes include the auto PR list and linked health-checkup issues