### PR TITLE
docs: require health-checkup before every PR (prefer subagent)

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -12,53 +12,56 @@ AI drives implementation; humans focus on quality assurance and final decisions.
 1. **Human/AI**: Open a request as a GitHub Issue (what — background, requirements, acceptance criteria)
 2. **AI**: Read the issue with `gh issue view` and propose an implementation plan
 3. **Human**: Review the plan and approve with `cursor:implement` on the issue
-4. **AI**: Implement per the approved plan, pass tests, and open a PR
-5. **AI**: Review the PR when it is opened (`review-pull-request`; Cursor Automation)
-6. **Human**: Review behavior, Storybook, etc., and leave feedback
-7. **AI**: Address review feedback when triggered (`address-pr-review`; Cursor Automation)
-8. **Human**: Re-check and merge
+4. **AI**: Implement per the approved plan, pass tests
+5. **AI**: Before opening the PR — `health-checkup` (prefer fresh subagent) then `self-review` — then open the PR
+6. **AI**: Review the PR when it is opened (`review-pull-request`; Cursor Automation)
+7. **Human**: Review behavior, Storybook, etc., and leave feedback
+8. **AI**: Address review feedback when triggered (`address-pr-review`; Cursor Automation)
+9. **Human**: Re-check and merge
 
 ```mermaid
 flowchart TD
   A["👤🤖 Issue (what)"] --> B["🤖 Implementation plan"]
   B --> C["👤 cursor:implement"]
-  C --> D["🤖 implement → PR"]
-  D --> E["🤖 review PR"]
-  E --> F["👤 review + feedback"]
-  F --> G["🤖 address review"]
-  G --> H["👤 merge"]
-  H -->|periodically, after merges accumulate| I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
-  I --> J["🤖 health-checkup"]
+  C --> D["🤖 implement"]
+  D --> E["🤖 health-checkup + self-review → PR"]
+  E --> F["🤖 review PR"]
+  F --> G["👤 review + feedback"]
+  G --> H["🤖 address review"]
+  H --> I["👤 merge"]
+  I -->|periodically, after merges accumulate| J["🤖 version-up — dedicated release PR"]
   J --> A
   L["💡 continuous-improvement"] -.separate PR.-> A
-  R["🔄 Renovate — dependency PRs (separate)"] -.-> E
+  R["🔄 Renovate — dependency PRs (separate)"] -.-> F
 ```
 
 - Do not implement before the plan is approved (`cursor:implement` on the issue).
 - Do not change beyond the approved scope.
+- Do not open a PR without a pre-PR `health-checkup` (prefer separate context) and `self-review`.
 - Implementation steps: `implement-issue` skill. Layout: `project-structure` skill. Language: English.
 
 ## Release cycle
 
 Periodically, after merged work accumulates, cut a release of **syakoo-lab itself**: run the
-`version-up` skill (bump this repo's own `package.json` `version` + change summary), which hands off
-to the `health-checkup` skill (design-drift audit). Both run as a dedicated PR, separate from
-feature work. This is the project's own release ritual—distinct from Renovate's dependency-update
-PRs, which simply follow the same review path above.
+`version-up` skill as a **dedicated PR** (bump this repo's own `package.json` `version` + change
+summary + release-window `health-checkup`). That PR still goes through the same pre-PR gates and
+human review as feature work. Distinct from Renovate's dependency-update PRs.
 
 ## Subagents
 
 Delegate routine work via Task. Pass only what the subagent needs.
 
-Delegate only when a step is part of this flow **and** its journey needn't be watched—delegation
-just trims context. Keep steps whose output needs human judgment (`version-up`, `health-checkup`)
-in the main agent.
+Delegate when a step is part of this flow **and** its journey needn't be watched—delegation trims
+context and, for checkup/review, keeps a **clean context**. Prefer a fresh subagent for
+`health-checkup` and `self-review` before PR open. Keep `version-up` orchestration in the main agent
+(it may still spawn checkup/review subagents).
 
 | When | Subagent |
 |------|----------|
 | Create issue | `create-github-issue` |
 | Implement | `implement-issue` |
-| Before push | `self-review` |
+| Before PR — design health | `health-checkup` (prefer fresh subagent) |
+| Before push / PR — hygiene | `self-review` |
 | Open PR | `create-pull-request` |
 | PR opened | `review-pull-request` |
 | Review feedback | `address-pr-review` |

--- a/.cursor/rules/enforcement-inventory.mdc
+++ b/.cursor/rules/enforcement-inventory.mdc
@@ -39,10 +39,10 @@ Routes each standard to its enforcement owner. This is an **index**: rule text l
 | AI workflow (plan → implement → PR) | Agent | `ai-workflow` rule |
 | PR body format | Agent | `create-pull-request` skill |
 | PR review checklist | Agent | `review-pull-request` skill |
-| Pre-push self-review | Agent | `self-review` skill |
+| Pre-push / pre-PR self-review | Agent | `self-review` skill |
 | Codify lessons after trial-and-error | Agent | `continuous-improvement` rule |
 | Single source of truth | Agent | `single-source-of-truth` rule |
-| Periodic design checkup | Agent | `health-checkup` skill |
+| Pre-PR design checkup (also release-window via version-up) | Agent | `health-checkup` skill |
 | Project release / version bump | Agent | `version-up` skill |
 
 ## Config-only exceptions

--- a/.cursor/skills/create-pull-request/SKILL.md
+++ b/.cursor/skills/create-pull-request/SKILL.md
@@ -12,8 +12,12 @@ description: >-
 
 1. Confirm the target issue and approved implementation plan.
 2. Read `git diff` and changed files.
-3. Draft title and body in the format below.
-4. Run `gh pr create`.
+3. **Run `health-checkup`** over this branch vs the PR base (required). Prefer a **fresh subagent** with a clean context; pass only repo path, base ref, and the diff scope. Fold the report into **Impact and risks** (and file issues for actionable items the checkup did not already file).
+4. Run `self-review` (or the `self-review` subagent) so mechanical AI-review noise is cleared before the PR is opened.
+5. Draft title and body in the format below.
+6. Run `gh pr create`.
+
+Do **not** open the PR until steps 3–4 are done (or the user explicitly waives them).
 
 ## Title
 
@@ -40,7 +44,7 @@ One short line that states intent. No prefix required.
 
 ## Impact and risks
 
-(State "None" if there are none.)
+(State "None" if there are none. Include health-checkup outcome: issue links, declined items, or "No actionable findings".)
 ````
 
 ## Rules
@@ -48,5 +52,6 @@ One short line that states intent. No prefix required.
 - **Problem** and **Solution** are required.
 - **Design** only when introducing or changing architecture; omit the section if N/A.
 - **Impact and risks** is required even when the answer is "None".
-- List any intentional **advisory deviation** (deep modules, design-it-twice, Tailwind tokens, missing tests, Storybook) under **Impact and risks** so it surfaces at the next health checkup.
+- List any intentional **advisory deviation** (deep modules, design-it-twice, Tailwind tokens, missing tests, Storybook) under **Impact and risks** so later checkups can see the trail.
+- Record the pre-PR **health-checkup** result under **Impact and risks**.
 - Do not guess intent—ask a human when unclear.

--- a/.cursor/skills/health-checkup/SKILL.md
+++ b/.cursor/skills/health-checkup/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: health-checkup
 description: >-
-  Periodic code health checkup for design drift not caught by CI. Use at version
-  bumps or when asked for a code health check / 健康診断 / 健診. Audits logged advisory
-  deviations and runs a deepen-modules pass.
+  Design-health checkup for drift CI cannot catch. Always run before opening a PR
+  (prefer a fresh subagent / separate context); also used by version-up for a
+  release-window audit. Audits advisory deviations and runs a deepen-modules pass.
 ---
 
 # Health checkup
 
-Catches what CI cannot: design drift (deep modules, layering, abstractions) that accumulates silently between checkups.
+Catches what CI cannot: design drift (deep modules, layering, abstractions) that accumulates silently.
 
 ## Review model (context for the checkup)
 
@@ -21,11 +21,28 @@ Catches what CI cannot: design drift (deep modules, layering, abstractions) that
 
 The audit only works if drift left a trail: every PR logs intentional advisory deviations under **Impact and risks** (`create-pull-request` skill). An undocumented deviation is the one a checkup cannot find.
 
+## When to use
+
+- **Before every PR** (required gate in `create-pull-request`). Scope: the branch's changes vs the PR base (usually `main`).
+- **Release window** (triggered by `version-up`). Scope: everything merged since the last release.
+- When the user asks for a code health check / 健康診断 / 健診.
+
+Prefer running this skill via a **fresh subagent** (Task / clean context) so the checkup is not biased by the implementer's session history. The caller passes only: repo path, scope (PR diff or since-tag), and where to put findings.
+
 ## Procedure
 
-Run at each release; keep the interval small (design debt compounds).
+1. Determine scope:
+   - Pre-PR: `git diff <base>...HEAD` and changed paths.
+   - Release: changes / merged PRs since the last release tag (or last version bump).
+2. Read advisory deviations already logged for that scope (PR drafts, recent PR **Impact and risks**).
+3. Run the `deepen-modules` skill as a structured pass over the scoped areas.
+4. Re-check advisory items in `coding-guide` (Tailwind tokens, Storybook coverage, tests for behavior changes).
+5. Report findings. For each **actionable** item: file a GitHub issue (`create-github-issue`) or, if tiny and in the current PR's approved scope, fix it in-branch. Give declined / intentional items a one-line rationale for **Impact and risks**.
 
-1. Read advisory deviations logged in PR **Impact and risks** since the last checkup.
-2. Run the `deepen-modules` skill as a structured pass over the areas changed since then.
-3. Re-check advisory items in `coding-guide` (Tailwind tokens, Storybook coverage, tests for behavior changes).
-4. File issues for what is worth fixing; address small drift in a dedicated PR, separate from features.
+## Output for the caller
+
+Return a short report the PR author can paste or paraphrase:
+
+- Actionable findings (issue links or in-branch fixes)
+- Declined / intentional items (one line each)
+- "No actionable findings" when clean

--- a/.cursor/skills/implement-issue/SKILL.md
+++ b/.cursor/skills/implement-issue/SKILL.md
@@ -54,7 +54,8 @@ git commit -m "<message>"
 git push -u origin HEAD
 ```
 
-After push, create the PR per `create-pull-request`.
+After push, create the PR per `create-pull-request` (that skill requires a pre-PR
+`health-checkup` — prefer a fresh subagent — and `self-review` before `gh pr create`).
 
 ## Important
 

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -34,13 +34,17 @@ Run as a **dedicated PR, separate from feature work** (consistent with `continuo
 3. **Apply the bump.** Update `version` in `package.json` only.
 4. **Write a change summary** since the last release, derived from merged PRs / `git log`. Group by
    the kind of change (features, fixes, internal) so it doubles as release notes.
-5. **Hand off to `health-checkup`.** Run that skill over everything changed since the last release
-   (design-drift audit + `deepen-modules` pass). The version bump is its trigger.
-6. **Open the release PR** per `create-pull-request`, including the change summary.
+5. **Run `health-checkup`** over everything changed since the last release (prefer a fresh
+   subagent). File issues for actionable findings; keep declined items for the PR body. Feature
+   PRs already ran a pre-PR checkup; this pass is the **release-window** sweep.
+6. **Open the release PR** per `create-pull-request` (which also runs the normal pre-PR
+   checkup + self-review on this bump branch). Include the change summary and release-window
+   checkup outcome.
 
 ## Caveats
 
-- Keep release intervals small: the smaller the window, the cheaper the `health-checkup`
+- Keep release intervals small: the smaller the window, the cheaper the release-window checkup
   (design debt compounds).
 - Do not mix a release bump with feature changes in the same PR.
-- The canonical checkup procedure lives in `health-checkup`; this skill only triggers it.
+- The canonical checkup procedure lives in `health-checkup`; this skill only triggers the
+  release-scoped run. Per-PR checkups are owned by `create-pull-request`.


### PR DESCRIPTION
## Problem

#301 tried to cut releases without a review PR (direct-to-`main` bump). After more thought, that removes the audit gate we actually want. Separately, design drift was only checked at release time, so feature PRs could land shallow modules for weeks.

Refs the closed experiment: #301.

## Solution

- **Close the no-PR release path.** `version-up` stays a **dedicated release PR** (bump + change summary + release-window checkup).
- **`health-checkup` is a pre-PR gate** for every PR (`create-pull-request`), scoped to the branch vs base. Prefer a **fresh subagent** so the checkup is not biased by the implementer session.
- Keep **`self-review`** before PR open so Automation review sees less mechanical AI noise.
- Wire the same expectations into `ai-workflow`, `implement-issue`, `enforcement-inventory`, and `version-up` (release-window sweep remains explicit; per-PR gate is owned by `create-pull-request`).

## Impact and risks

- Docs/skills/rules only — no runtime changes.
- Pre-PR checkup adds agent cost/latency before every PR; preferred mitigation is a separate-context subagent.
- Health-checkup on this PR itself: docs-only skill/rule wording — **no actionable findings**.

## Test plan

- [ ] Next feature implementation follows: checkup (subagent) → self-review → `gh pr create`
- [ ] Next `version-up` still opens a dedicated PR and runs a release-window checkup
- [ ] Automation PR review still runs; pre-cleared mechanical issues should be rarer

Made with [Cursor](https://cursor.com)