### PR TITLE
ci: auto bump version and release from semver:* labels on merge

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -27,8 +27,7 @@ flowchart TD
   E --> F["👤 review + feedback"]
   F --> G["🤖 address review"]
   G --> H["👤 merge"]
-  H -->|periodically, after merges accumulate| I["🤖 version-up — syakoo-lab's own release (dedicated PR)"]
-  I --> J["🤖 health-checkup"]
+  H --> J["⚙️ semver:* label → auto bump + GH Release"]
   J --> A
   L["💡 continuous-improvement"] -.separate PR.-> A
   R["🔄 Renovate — dependency PRs (separate)"] -.-> E
@@ -37,22 +36,22 @@ flowchart TD
 - Do not implement before the plan is approved (`cursor:implement` on the issue).
 - Do not change beyond the approved scope.
 - Implementation steps: `implement-issue` skill. Layout: `project-structure` skill. Language: English.
+- Every PR to `main` must carry exactly one `semver:major` / `semver:minor` / `semver:patch` label (CI). On merge, Actions bumps `package.json` and publishes the GitHub Release. `renovate[bot]` defaults to patch.
 
 ## Release cycle
 
-Periodically, after merged work accumulates, cut a release of **syakoo-lab itself**: run the
-`version-up` skill (bump this repo's own `package.json` `version` + change summary), which hands off
-to the `health-checkup` skill (design-drift audit). Both run as a dedicated PR, separate from
-feature work. This is the project's own release ritual—distinct from Renovate's dependency-update
-PRs, which simply follow the same review path above.
+**Automated.** Feature/fix/chore PRs declare their semver impact with a label; merging to `main`
+is the release. The `version-up` skill is only for recovery or rare manual overrides — not a
+periodic dedicated release PR. Distinct from Renovate's dependency-update PRs (same review path;
+patch bump by default).
 
 ## Subagents
 
 Delegate routine work via Task. Pass only what the subagent needs.
 
 Delegate only when a step is part of this flow **and** its journey needn't be watched—delegation
-just trims context. Keep steps whose output needs human judgment (`version-up`, `health-checkup`)
-in the main agent.
+just trims context. Keep steps whose output needs human judgment (`health-checkup`) in the main
+agent when not using a fresh subagent.
 
 | When | Subagent |
 |------|----------|

--- a/.cursor/rules/enforcement-inventory.mdc
+++ b/.cursor/rules/enforcement-inventory.mdc
@@ -43,7 +43,7 @@ Routes each standard to its enforcement owner. This is an **index**: rule text l
 | Codify lessons after trial-and-error | Agent | `continuous-improvement` rule |
 | Single source of truth | Agent | `single-source-of-truth` rule |
 | Periodic design checkup | Agent | `health-checkup` skill |
-| Project release / version bump | Agent | `version-up` skill |
+| Project release / version bump | CI | `semver:*` PR label + `version-bump-on-merge` workflow (`version-up` skill = recovery only) |
 
 ## Config-only exceptions
 

--- a/.cursor/skills/create-pull-request/SKILL.md
+++ b/.cursor/skills/create-pull-request/SKILL.md
@@ -13,7 +13,8 @@ description: >-
 1. Confirm the target issue and approved implementation plan.
 2. Read `git diff` and changed files.
 3. Draft title and body in the format below.
-4. Run `gh pr create`.
+4. Run `gh pr create` with **exactly one** semver label: `semver:major`, `semver:minor`, or
+   `semver:patch` (CI requires it; merge auto-bumps and releases from that label).
 
 ## Title
 
@@ -49,4 +50,5 @@ One short line that states intent. No prefix required.
 - **Design** only when introducing or changing architecture; omit the section if N/A.
 - **Impact and risks** is required even when the answer is "None".
 - List any intentional **advisory deviation** (deep modules, design-it-twice, Tailwind tokens, missing tests, Storybook) under **Impact and risks** so it surfaces at the next health checkup.
+- Attach exactly one **`semver:*` label** when opening the PR (`major` = breaking, `minor` = feature, `patch` = fix/docs/chore).
 - Do not guess intent—ask a human when unclear.

--- a/.cursor/skills/version-up/SKILL.md
+++ b/.cursor/skills/version-up/SKILL.md
@@ -1,46 +1,47 @@
 ---
 name: version-up
 description: >-
-  Perform a project release: bump the semver `version` in package.json, summarize
-  changes since the last release, and hand off to the health-checkup. Use when
-  cutting a release, bumping the project version, or asked to "version up".
+  Explain or override the automated release path. Versions normally bump on each
+  merge to main from the PR's semver:* label. Use when asked to "version up", to
+  recover a failed auto-release, or for an exceptional manual bump.
 ---
 
 # Version up
 
-The release ritual for **syakoo-lab itself**: bump this project's own `version` in `package.json`
-and run the design checkup that must accompany it.
+**Normal path (no skill run):** every PR to `main` carries exactly one of
+`semver:major` / `semver:minor` / `semver:patch`. CI enforces the label.
+On merge, `.github/workflows/version-bump-on-merge.yml` bumps `package.json` via
+the signed Contents API and publishes GitHub Release `vX.Y.Z` with generated notes.
+`renovate[bot]` PRs may omit the label and default to **patch**.
 
-This is the project's own release, not a dependency update. (Dependency-update PRs are a separate,
-Renovate-automated concern and are out of scope here.)
+This skill is for **exceptions**, not the routine release.
 
 ## When to use
 
-- Cutting a new release of syakoo-lab (changing this repo's `package.json` `version`).
-- Whenever enough merged work has accumulated to warrant a release.
+- Auto-bump / release failed and needs a manual retry
+- An exceptional bump with no mergeable PR (rare)
+- Explaining the release model to a human or agent
 
-Not for dependency bumps or feature work.
+Not for ordinary feature/fix/chore PRs — put a `semver:*` label on those instead.
 
-## Procedure
+## Label guide (for PR authors)
 
-Run as a **dedicated PR, separate from feature work** (consistent with `continuous-improvement`).
+| Label | Use when |
+|-------|----------|
+| `semver:major` | Breaking change to public behavior or APIs |
+| `semver:minor` | Backward-compatible feature |
+| `semver:patch` | Fix, docs, chore, or internal-only |
 
-1. **Find the last release.** Read the current `version` in `package.json` and locate the previous
-   bump (`git log --oneline -- package.json` or the latest release tag).
-2. **Decide the semver bump.** Choose major / minor / patch from the change set:
-   - major: breaking change to public behavior or APIs
-   - minor: backward-compatible feature
-   - patch: backward-compatible fix or docs/internal only
-3. **Apply the bump.** Update `version` in `package.json` only.
-4. **Write a change summary** since the last release, derived from merged PRs / `git log`. Group by
-   the kind of change (features, fixes, internal) so it doubles as release notes.
-5. **Hand off to `health-checkup`.** Run that skill over everything changed since the last release
-   (design-drift audit + `deepen-modules` pass). The version bump is its trigger.
-6. **Open the release PR** per `create-pull-request`, including the change summary.
+## Manual recovery
+
+1. Confirm the intended next version from `package.json` and `gh release list`.
+2. Bump only `version` in `package.json` (or `scripts/bump-semver.sh <level>`).
+3. Land it with a signed commit on `main` (Contents API if local signing is unavailable).
+4. `gh release create vX.Y.Z --target main --generate-notes --notes-start-tag v<prev>`.
 
 ## Caveats
 
-- Keep release intervals small: the smaller the window, the cheaper the `health-checkup`
-  (design debt compounds).
-- Do not mix a release bump with feature changes in the same PR.
-- The canonical checkup procedure lives in `health-checkup`; this skill only triggers it.
+- Design health is **not** this skill's job. Pre-PR `health-checkup` (see `create-pull-request` /
+  `ai-workflow`) owns drift audits.
+- Do not open a dedicated "release PR" for routine bumps — the merge workflow is the release.
+- Multiple `semver:*` labels: the workflow prefers major > minor > patch; CI requires exactly one.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
             echo "renovate[bot]: semver label optional (defaults to patch on merge)."
             exit 0
           fi
+          IFS=',' read -r -a label_arr <<< "$LABELS"
           count=0
-          [[ "$LABELS" == *"semver:major"* ]] && count=$((count + 1))
-          [[ "$LABELS" == *"semver:minor"* ]] && count=$((count + 1))
-          [[ "$LABELS" == *"semver:patch"* ]] && count=$((count + 1))
+          for label in "${label_arr[@]}"; do
+            case "$label" in
+              semver:major|semver:minor|semver:patch) count=$((count + 1)) ;;
+            esac
+          done
           if [[ "$count" -eq 1 ]]; then
             echo "OK: semver label present."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,31 @@ env:
   NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: "dummy-ga-id"
 
 jobs:
+  semver-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require exactly one semver:* label
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          if [[ "$AUTHOR" == "renovate[bot]" ]]; then
+            echo "renovate[bot]: semver label optional (defaults to patch on merge)."
+            exit 0
+          fi
+          count=0
+          [[ "$LABELS" == *"semver:major"* ]] && count=$((count + 1))
+          [[ "$LABELS" == *"semver:minor"* ]] && count=$((count + 1))
+          [[ "$LABELS" == *"semver:patch"* ]] && count=$((count + 1))
+          if [[ "$count" -eq 1 ]]; then
+            echo "OK: semver label present."
+            exit 0
+          fi
+          echo "::error::Add exactly one of: semver:major, semver:minor, semver:patch (got ${count})."
+          exit 1
+
   security-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/version-bump-on-merge.yml
+++ b/.github/workflows/version-bump-on-merge.yml
@@ -9,6 +9,10 @@ on:
     types: [closed]
     branches: [main]
 
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: read
@@ -26,28 +30,35 @@ jobs:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
-          if [[ "$LABELS" == *"semver:major"* ]]; then
+          IFS=',' read -r -a label_arr <<< "$LABELS"
+          has() {
+            local needle=$1
+            local label
+            for label in "${label_arr[@]}"; do
+              [[ "$label" == "$needle" ]] && return 0
+            done
+            return 1
+          }
+          if has semver:major; then
             level=major
-          elif [[ "$LABELS" == *"semver:minor"* ]]; then
+          elif has semver:minor; then
             level=minor
-          elif [[ "$LABELS" == *"semver:patch"* ]]; then
+          elif has semver:patch; then
             level=patch
           elif [[ "$AUTHOR" == "renovate[bot]" ]]; then
             level=patch
           else
-            echo "No semver:* label (and not renovate[bot]); skipping bump."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Merged without semver:* label (and not renovate[bot]). No release was published — recover with version-up."
+            exit 1
           fi
           echo "level=$level" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout
-        if: steps.level.outputs.skip != 'true'
+      - name: Checkout merge commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Bump package.json and publish release
-        if: steps.level.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LEVEL: ${{ steps.level.outputs.level }}

--- a/.github/workflows/version-bump-on-merge.yml
+++ b/.github/workflows/version-bump-on-merge.yml
@@ -1,0 +1,84 @@
+name: Version bump on merge
+
+# After a PR merges to main, bump package.json from its semver:* label and
+# publish a GitHub Release. Trigger is pull_request closed (not push), so the
+# Contents-API bump commit does not re-enter this workflow.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve bump level
+        id: level
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          if [[ "$LABELS" == *"semver:major"* ]]; then
+            level=major
+          elif [[ "$LABELS" == *"semver:minor"* ]]; then
+            level=minor
+          elif [[ "$LABELS" == *"semver:patch"* ]]; then
+            level=patch
+          elif [[ "$AUTHOR" == "renovate[bot]" ]]; then
+            level=patch
+          else
+            echo "No semver:* label (and not renovate[bot]); skipping bump."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.level.outputs.skip != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Bump package.json and publish release
+        if: steps.level.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEVEL: ${{ steps.level.outputs.level }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/bump-semver.sh
+          old="$(node -p "require('./package.json').version")"
+          new="$(./scripts/bump-semver.sh "$LEVEL")"
+          echo "Bump $old → $new ($LEVEL)"
+
+          if gh release view "v${new}" >/dev/null 2>&1; then
+            echo "Release v${new} already exists; aborting to avoid overwrite."
+            exit 1
+          fi
+
+          # main requires signed commits — Contents API commits are signed by GitHub.
+          CONTENT="$(base64 -w0 package.json 2>/dev/null || base64 < package.json | tr -d '\n')"
+          SHA="$(gh api "repos/${REPO}/contents/package.json" --jq .sha)"
+          gh api -X PUT "repos/${REPO}/contents/package.json" \
+            -f message="chore: bump version to ${new}" \
+            -f sha="$SHA" \
+            -f content="$CONTENT"
+
+          notes="$(gh api "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="v${new}" \
+            -f previous_tag_name="v${old}" \
+            -f target_commitish=main \
+            --jq .body)"
+
+          gh release create "v${new}" \
+            --target main \
+            --title "v${new}" \
+            --notes "$notes"

--- a/scripts/bump-semver.mjs
+++ b/scripts/bump-semver.mjs
@@ -13,7 +13,9 @@ import { fileURLToPath } from "node:url";
  * @returns {string}
  */
 export function bumpSemver(version, level) {
-  const parts = String(version).split(".").map((n) => Number(n));
+  const parts = String(version)
+    .split(".")
+    .map((n) => Number(n));
   if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
     throw new Error(`invalid version: ${version}`);
   }
@@ -41,7 +43,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     process.exit(1);
   }
   const pkg = JSON.parse(readFileSync(file, "utf8"));
-  pkg.version = bumpSemver(pkg.version, /** @type {"major"|"minor"|"patch"} */ (level));
+  pkg.version = bumpSemver(
+    pkg.version,
+    /** @type {"major"|"minor"|"patch"} */ (level),
+  );
   writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
   console.log(pkg.version);
 }

--- a/scripts/bump-semver.mjs
+++ b/scripts/bump-semver.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Bump package.json "version" in-place.
+ * Usage: node scripts/bump-semver.mjs major|minor|patch [path/to/package.json]
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @param {string} version
+ * @param {"major" | "minor" | "patch"} level
+ * @returns {string}
+ */
+export function bumpSemver(version, level) {
+  const parts = String(version).split(".").map((n) => Number(n));
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(`invalid version: ${version}`);
+  }
+  let [major, minor, patch] = parts;
+  if (level === "major") {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (level === "minor") {
+    minor += 1;
+    patch = 0;
+  } else if (level === "patch") {
+    patch += 1;
+  } else {
+    throw new Error(`invalid level: ${level}`);
+  }
+  return `${major}.${minor}.${patch}`;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const level = process.argv[2];
+  const file = process.argv[3] ?? "package.json";
+  if (!level) {
+    console.error("usage: bump-semver.mjs major|minor|patch [package.json]");
+    process.exit(1);
+  }
+  const pkg = JSON.parse(readFileSync(file, "utf8"));
+  pkg.version = bumpSemver(pkg.version, /** @type {"major"|"minor"|"patch"} */ (level));
+  writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(pkg.version);
+}

--- a/scripts/bump-semver.sh
+++ b/scripts/bump-semver.sh
@@ -1,25 +1,5 @@
 #!/usr/bin/env bash
-# Bump package.json "version" in-place. Usage: bump-semver.sh major|minor|patch
+# Bump package.json "version" in-place. Usage: bump-semver.sh major|minor|patch [package.json]
 set -euo pipefail
-
-level="${1:?usage: bump-semver.sh major|minor|patch}"
-file="${2:-package.json}"
-
-node --input-type=module -e "
-import { readFileSync, writeFileSync } from 'node:fs';
-const file = process.argv[1];
-const level = process.argv[2];
-const pkg = JSON.parse(readFileSync(file, 'utf8'));
-const parts = String(pkg.version).split('.').map((n) => Number(n));
-if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
-  throw new Error(\`invalid version: \${pkg.version}\`);
-}
-let [major, minor, patch] = parts;
-if (level === 'major') { major += 1; minor = 0; patch = 0; }
-else if (level === 'minor') { minor += 1; patch = 0; }
-else if (level === 'patch') { patch += 1; }
-else { throw new Error(\`invalid level: \${level}\`); }
-pkg.version = \`\${major}.\${minor}.\${patch}\`;
-writeFileSync(file, \`\${JSON.stringify(pkg, null, 2)}\\n\`);
-console.log(pkg.version);
-" "$file" "$level"
+root="$(cd "$(dirname "$0")/.." && pwd)"
+exec node "$root/scripts/bump-semver.mjs" "$@"

--- a/scripts/bump-semver.sh
+++ b/scripts/bump-semver.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Bump package.json "version" in-place. Usage: bump-semver.sh major|minor|patch
+set -euo pipefail
+
+level="${1:?usage: bump-semver.sh major|minor|patch}"
+file="${2:-package.json}"
+
+node --input-type=module -e "
+import { readFileSync, writeFileSync } from 'node:fs';
+const file = process.argv[1];
+const level = process.argv[2];
+const pkg = JSON.parse(readFileSync(file, 'utf8'));
+const parts = String(pkg.version).split('.').map((n) => Number(n));
+if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n) || n < 0)) {
+  throw new Error(\`invalid version: \${pkg.version}\`);
+}
+let [major, minor, patch] = parts;
+if (level === 'major') { major += 1; minor = 0; patch = 0; }
+else if (level === 'minor') { minor += 1; patch = 0; }
+else if (level === 'patch') { patch += 1; }
+else { throw new Error(\`invalid level: \${level}\`); }
+pkg.version = \`\${major}.\${minor}.\${patch}\`;
+writeFileSync(file, \`\${JSON.stringify(pkg, null, 2)}\\n\`);
+console.log(pkg.version);
+" "$file" "$level"

--- a/scripts/bump-semver.test.ts
+++ b/scripts/bump-semver.test.ts
@@ -20,8 +20,9 @@ describe("bumpSemver", () => {
   });
 
   it("rejects invalid level", () => {
-    expect(() => bumpSemver("1.2.3", /** @type {never} */ ("foo"))).toThrow(
-      /invalid level/,
-    );
+    expect(() =>
+      // @ts-expect-error intentional invalid level for runtime guard
+      bumpSemver("1.2.3", "foo"),
+    ).toThrow(/invalid level/);
   });
 });

--- a/scripts/bump-semver.test.ts
+++ b/scripts/bump-semver.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { bumpSemver } from "./bump-semver.mjs";
+
+describe("bumpSemver", () => {
+  it("bumps patch", () => {
+    expect(bumpSemver("1.2.3", "patch")).toBe("1.2.4");
+  });
+
+  it("bumps minor and resets patch", () => {
+    expect(bumpSemver("1.2.3", "minor")).toBe("1.3.0");
+  });
+
+  it("bumps major and resets minor/patch", () => {
+    expect(bumpSemver("1.2.3", "major")).toBe("2.0.0");
+  });
+
+  it("rejects invalid version", () => {
+    expect(() => bumpSemver("1.2", "patch")).toThrow(/invalid version/);
+  });
+
+  it("rejects invalid level", () => {
+    expect(() => bumpSemver("1.2.3", /** @type {never} */ ("foo"))).toThrow(
+      /invalid level/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Version bumps were a human/agent ritual (`version-up` dedicated PR + manual tag/release). Semver judgment does not need a person; merge already reviewed the change.

## Solution

- **CI** requires exactly one of `semver:major` / `semver:minor` / `semver:patch` on every PR (`renovate[bot]` exempt; defaults to patch on merge).
- **On merge to `main`**: `version-bump-on-merge` workflow bumps `package.json` via the signed Contents API and publishes GitHub Release `vX.Y.Z` with generated notes.
- **`version-up` skill** rewritten as recovery / docs only — no routine dedicated release PR.
- Agents creating PRs must attach the label (`create-pull-request`).

Labels `semver:*` already created on the repo.

## Impact and risks

- First merge after this lands will bump `6.2.0` → `6.2.1` (this PR is labeled `semver:patch`).
- `main` signed-commit rule: bump uses Contents API (same approach as earlier experiments).
- Branch protection does **not** yet mark `semver-label` as a required check — worth adding in repo settings so unlabeled PRs cannot merge.
- Conflicts likely with #302 (`ai-workflow` / `create-pull-request`); merge one then rebase the other.
- Health-checkup remains separate (#302). This PR only automates version/release.

## Test plan

- [ ] CI `semver-label` fails without a label; passes with exactly one
- [ ] After merge: `package.json` bumps, `vX.Y.Z` release appears, tag points at main
- [ ] Renovate PR without label still merges and patch-bumps
- [ ] Optionally require `semver-label` status check on `main`

Made with [Cursor](https://cursor.com)