### PR TITLE
ci: re-check semver label when labels change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,34 +7,6 @@ env:
   NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: "dummy-ga-id"
 
 jobs:
-  semver-label:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Require exactly one semver:* label
-        env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          set -euo pipefail
-          if [[ "$AUTHOR" == "renovate[bot]" ]]; then
-            echo "renovate[bot]: semver label optional (defaults to patch on merge)."
-            exit 0
-          fi
-          IFS=',' read -r -a label_arr <<< "$LABELS"
-          count=0
-          for label in "${label_arr[@]}"; do
-            case "$label" in
-              semver:major|semver:minor|semver:patch) count=$((count + 1)) ;;
-            esac
-          done
-          if [[ "$count" -eq 1 ]]; then
-            echo "OK: semver label present."
-            exit 0
-          fi
-          echo "::error::Add exactly one of: semver:major, semver:minor, semver:patch (got ${count})."
-          exit 1
-
   security-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -1,0 +1,38 @@
+name: Semver label
+
+# Separate from main CI so adding/changing a semver:* label re-checks without
+# re-running lint/tests/storybook. Fixes the race where CI runs on PR open
+# before the label is attached (e.g. agent labels after create).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  semver-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require exactly one semver:* label
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          if [[ "$AUTHOR" == "renovate[bot]" ]]; then
+            echo "renovate[bot]: semver label optional (defaults to patch on merge)."
+            exit 0
+          fi
+          IFS=',' read -r -a label_arr <<< "$LABELS"
+          count=0
+          for label in "${label_arr[@]}"; do
+            case "$label" in
+              semver:major|semver:minor|semver:patch) count=$((count + 1)) ;;
+            esac
+          done
+          if [[ "$count" -eq 1 ]]; then
+            echo "OK: semver label present."
+            exit 0
+          fi
+          echo "::error::Add exactly one of: semver:major, semver:minor, semver:patch (got ${count})."
+          exit 1


### PR DESCRIPTION
## Problem

On #304 the `semver-label` check ran on PR open before `semver:patch` was attached, failed, and stayed red. Default `pull_request` events do not include `labeled` / `unlabeled`, and re-running a failed job reuses the original (label-less) event payload.

Refs #304.

## Solution

- Extract `semver-label` into `.github/workflows/semver-label.yml`
- Trigger on `opened`, `synchronize`, `reopened`, **`labeled`**, **`unlabeled`**
- Keep heavy CI on the normal `pull_request` path only (no full re-run on label changes)

## Impact and risks

- Workflow-only. After this merges, toggle a `semver:*` label on #304 (remove + re-add, or change) to get a fresh green check — plain “Re-run” is not enough.
- If `semver-label` is a required status check, confirm the check name still matches after the workflow split (job id remains `semver-label`).

## Test plan

- [ ] Open a PR without a label → `semver-label` fails
- [ ] Add exactly one `semver:*` → check re-runs and passes (without re-running full CI)
- [ ] On #304, toggle `semver:patch` after this lands → check goes green

Made with [Cursor](https://cursor.com)